### PR TITLE
wildcard characters for metric names

### DIFF
--- a/mackerel-plugin.go
+++ b/mackerel-plugin.go
@@ -186,6 +186,7 @@ func (h *MackerelPlugin) formatValues(prefix string, metric Metrics, stat *map[s
 			}
 		} else {
 			log.Printf("%s does not exist at last fetch\n", metric.Name)
+			return
 		}
 	}
 

--- a/mackerel-plugin.go
+++ b/mackerel-plugin.go
@@ -208,20 +208,16 @@ func (h *MackerelPlugin) formatValues(prefix string, metric Metrics, stat *map[s
 }
 
 func (h *MackerelPlugin) formatValuesWithWildcard(prefix string, metric Metrics, stat *map[string]interface{}, lastStat *map[string]interface{}, now time.Time, lastTime time.Time) {
-	regexp_str := prefix + "." + metric.Name
-	regexp_str = strings.Replace(regexp_str, ".", "\\.", -1)
-	regexp_str = strings.Replace(regexp_str, "*", "[-a-zA-Z0-9_]+", -1)
-	regexp_str = strings.Replace(regexp_str, "#", "[-a-zA-Z0-9_]+", -1)
-	re, err := regexp.Compile(regexp_str)
+	regexpStr := `\A` + prefix + "." + metric.Name
+	regexpStr = strings.Replace(regexpStr, ".", "\\.", -1)
+	regexpStr = strings.Replace(regexpStr, "*", "[-a-zA-Z0-9_]+", -1)
+	regexpStr = strings.Replace(regexpStr, "#", "[-a-zA-Z0-9_]+", -1)
+	re, err := regexp.Compile(regexpStr)
 	if err != nil {
 		log.Fatalln("Failed to compile regexp: ", err)
 	}
 	for k, _ := range *stat {
-		if re.FindString(k) != "" {
-			// should not call formatValues if metrics has the prefix '.last_diff.' or just '.'
-			if strings.HasPrefix(k, ".") {
-				continue
-			}
+		if re.MatchString(k) {
 			metricEach := metric
 			metricEach.Name = k
 			h.formatValues("", metricEach, stat, lastStat, now, lastTime)

--- a/mackerel-plugin.go
+++ b/mackerel-plugin.go
@@ -122,7 +122,7 @@ func (h *MackerelPlugin) calcDiffUint32(value uint32, now time.Time, lastValue u
 
 	diff := float64((value-lastValue)*60) / float64(diffTime)
 
-	if lastValue < value || diff < lastDiff*10 {
+	if lastValue <= value || diff < lastDiff*10 {
 		return diff, nil
 	}
 	return 0.0, errors.New("Counter seems to be reseted.")
@@ -137,7 +137,7 @@ func (h *MackerelPlugin) calcDiffUint64(value uint64, now time.Time, lastValue u
 
 	diff := float64((value-lastValue)*60) / float64(diffTime)
 
-	if lastValue < value || diff < lastDiff*10 {
+	if lastValue <= value || diff < lastDiff*10 {
 		return diff, nil
 	}
 	return 0.0, errors.New("Counter seems to be reseted.")

--- a/mackerel-plugin.go
+++ b/mackerel-plugin.go
@@ -218,6 +218,10 @@ func (h *MackerelPlugin) formatValuesWithWildcard(prefix string, metric Metrics,
 	}
 	for k, _ := range *stat {
 		if re.FindString(k) != "" {
+			// should not call formatValues if metrics has the prefix '.last_diff.' or just '.'
+			if strings.HasPrefix(k, ".") {
+				continue
+			}
 			metricEach := metric
 			metricEach.Name = k
 			h.formatValues("", metricEach, stat, lastStat, now, lastTime)

--- a/mackerel-plugin.go
+++ b/mackerel-plugin.go
@@ -185,7 +185,7 @@ func (h *MackerelPlugin) formatValues(prefix string, metric Metrics, stat *map[s
 				(*stat)[".last_diff."+metric.Name] = value
 			}
 		} else {
-			log.Printf("%s is not exist at last fetch\n", metric.Name)
+			log.Printf("%s does not exist at last fetch\n", metric.Name)
 		}
 	}
 

--- a/mackerel-plugin_test.go
+++ b/mackerel-plugin_test.go
@@ -127,6 +127,91 @@ func TestPrintValueFloat64(t *testing.T) {
 	}
 }
 
+func ExampleFormatValues() {
+	var mp MackerelPlugin
+	prefix := "foo"
+	metric := Metrics{Name: "cmd_get", Label: "Get", Diff: true, Type: "uint64"}
+	stat := map[string]interface{}{"cmd_get": uint64(1000)}
+	lastStat := map[string]interface{}{"cmd_get": uint64(500), ".last_diff.cmd_get": 300.0}
+	now := time.Unix(1437227240, 0)
+	lastTime := now.Add(-time.Duration(60) * time.Second)
+	mp.formatValues(prefix, metric, &stat, &lastStat, now, lastTime)
+
+	// Output:
+	// foo.cmd_get	500.000000	1437227240
+}
+
+func ExampleFormatValuesWithCounterReset() {
+	var mp MackerelPlugin
+	prefix := "foo"
+	metric := Metrics{Name: "cmd_get", Label: "Get", Diff: true, Type: "uint64"}
+	stat := map[string]interface{}{"cmd_get": uint64(10)}
+	lastStat := map[string]interface{}{"cmd_get": uint64(500), ".last_diff.cmd_get": 300.0}
+	now := time.Unix(1437227240, 0)
+	lastTime := now.Add(-time.Duration(60) * time.Second)
+	mp.formatValues(prefix, metric, &stat, &lastStat, now, lastTime)
+
+	// Output:
+}
+
+func ExampleFormatValuesWithOverflow() {
+	var mp MackerelPlugin
+	prefix := "foo"
+	metric := Metrics{Name: "cmd_get", Label: "Get", Diff: true, Type: "uint64"}
+	stat := map[string]interface{}{"cmd_get": uint64(500)}
+	lastStat := map[string]interface{}{"cmd_get": uint64(math.MaxUint64 - 100), ".last_diff.cmd_get": float64(1.0)}
+	now := time.Unix(1437227240, 0)
+	lastTime := now.Add(-time.Duration(60) * time.Second)
+	mp.formatValues(prefix, metric, &stat, &lastStat, now, lastTime)
+
+	// Output:
+}
+
+func ExampleFormatValuesWithWildcard() {
+	var mp MackerelPlugin
+	prefix := "foo.#"
+	metric := Metrics{Name: "bar", Label: "Get", Diff: true, Type: "uint64"}
+	stat := map[string]interface{}{"foo.1.bar": uint64(1000), "foo.2.bar": uint64(2000)}
+	lastStat := map[string]interface{}{"foo.1.bar": uint64(500), ".last_diff.foo.1.bar": float64(2.0), "foo.2.bar": uint64(1000), ".last_diff.foo.2.bar": float64(1.0)}
+	now := time.Unix(1437227240, 0)
+	lastTime := now.Add(-time.Duration(60) * time.Second)
+	mp.formatValuesWithWildcard(prefix, metric, &stat, &lastStat, now, lastTime)
+
+	// Output:
+	// foo.1.bar	500.000000	1437227240
+	// foo.2.bar	1000.000000	1437227240
+}
+
+func ExampleFormatValuesWithWildcardAndNoDiff() {
+	var mp MackerelPlugin
+	prefix := "foo.#"
+	metric := Metrics{Name: "bar", Label: "Get", Diff: false}
+	stat := map[string]interface{}{"foo.1.bar": float64(1000), "foo.2.bar": float64(2000)}
+	lastStat := map[string]interface{}{"foo.1.bar": float64(500), ".last_diff.foo.1.bar": float64(2.0), "foo.2.bar": float64(1000), ".last_diff.foo.2.bar": float64(1.0)}
+	now := time.Unix(1437227240, 0)
+	lastTime := now.Add(-time.Duration(60) * time.Second)
+	mp.formatValuesWithWildcard(prefix, metric, &stat, &lastStat, now, lastTime)
+
+	// Output:
+	// foo.1.bar	1000.000000	1437227240
+	// foo.2.bar	2000.000000	1437227240
+}
+
+func ExampleFormatValuesWithWildcardAstarisk() {
+	var mp MackerelPlugin
+	prefix := "foo"
+	metric := Metrics{Name: "*", Label: "Get", Diff: true, Type: "uint64"}
+	stat := map[string]interface{}{"foo.1": uint64(1000), "foo.2": uint64(2000)}
+	lastStat := map[string]interface{}{"foo.1": uint64(500), ".last_diff.foo.1": float64(2.0), "foo.2": uint64(1000), ".last_diff.foo.2": float64(1.0)}
+	now := time.Unix(1437227240, 0)
+	lastTime := now.Add(-time.Duration(60) * time.Second)
+	mp.formatValuesWithWildcard(prefix, metric, &stat, &lastStat, now, lastTime)
+
+	// Output:
+	// foo.1	500.000000	1437227240
+	// foo.2	1000.000000	1437227240
+}
+
 // an example implementation
 type MemcachedPlugin struct {
 }

--- a/mackerel-plugin_test.go
+++ b/mackerel-plugin_test.go
@@ -159,7 +159,34 @@ func ExampleFormatValuesWithOverflow() {
 	prefix := "foo"
 	metric := Metrics{Name: "cmd_get", Label: "Get", Diff: true, Type: "uint64"}
 	stat := map[string]interface{}{"cmd_get": uint64(500)}
-	lastStat := map[string]interface{}{"cmd_get": uint64(math.MaxUint64 - 100), ".last_diff.cmd_get": float64(1.0)}
+	lastStat := map[string]interface{}{"cmd_get": uint64(math.MaxUint64 - 100), ".last_diff.cmd_get": float64(100.0)}
+	now := time.Unix(1437227240, 0)
+	lastTime := now.Add(-time.Duration(60) * time.Second)
+	mp.formatValues(prefix, metric, &stat, &lastStat, now, lastTime)
+
+	// Output:
+	// foo.cmd_get	601.000000	1437227240
+}
+
+func ExampleFormatValuesWithOverflowAndTooHighDifference() {
+	var mp MackerelPlugin
+	prefix := "foo"
+	metric := Metrics{Name: "cmd_get", Label: "Get", Diff: true, Type: "uint64"}
+	stat := map[string]interface{}{"cmd_get": uint64(500)}
+	lastStat := map[string]interface{}{"cmd_get": uint64(math.MaxUint64 - 100), ".last_diff.cmd_get": float64(10.0)}
+	now := time.Unix(1437227240, 0)
+	lastTime := now.Add(-time.Duration(60) * time.Second)
+	mp.formatValues(prefix, metric, &stat, &lastStat, now, lastTime)
+
+	// Output:
+}
+
+func ExampleFormatValuesWithOverflowAndNoLastDiff() {
+	var mp MackerelPlugin
+	prefix := "foo"
+	metric := Metrics{Name: "cmd_get", Label: "Get", Diff: true, Type: "uint64"}
+	stat := map[string]interface{}{"cmd_get": uint64(500)}
+	lastStat := map[string]interface{}{"cmd_get": uint64(math.MaxUint64 - 100)}
 	now := time.Unix(1437227240, 0)
 	lastTime := now.Add(-time.Duration(60) * time.Second)
 	mp.formatValues(prefix, metric, &stat, &lastStat, now, lastTime)
@@ -172,29 +199,27 @@ func ExampleFormatValuesWithWildcard() {
 	prefix := "foo.#"
 	metric := Metrics{Name: "bar", Label: "Get", Diff: true, Type: "uint64"}
 	stat := map[string]interface{}{"foo.1.bar": uint64(1000), "foo.2.bar": uint64(2000)}
-	lastStat := map[string]interface{}{"foo.1.bar": uint64(500), ".last_diff.foo.1.bar": float64(2.0), "foo.2.bar": uint64(1000), ".last_diff.foo.2.bar": float64(1.0)}
+	lastStat := map[string]interface{}{"foo.1.bar": uint64(500), ".last_diff.foo.1.bar": float64(2.0)}
 	now := time.Unix(1437227240, 0)
 	lastTime := now.Add(-time.Duration(60) * time.Second)
 	mp.formatValuesWithWildcard(prefix, metric, &stat, &lastStat, now, lastTime)
 
 	// Output:
 	// foo.1.bar	500.000000	1437227240
-	// foo.2.bar	1000.000000	1437227240
 }
 
 func ExampleFormatValuesWithWildcardAndNoDiff() {
 	var mp MackerelPlugin
 	prefix := "foo.#"
 	metric := Metrics{Name: "bar", Label: "Get", Diff: false}
-	stat := map[string]interface{}{"foo.1.bar": float64(1000), "foo.2.bar": float64(2000)}
-	lastStat := map[string]interface{}{"foo.1.bar": float64(500), ".last_diff.foo.1.bar": float64(2.0), "foo.2.bar": float64(1000), ".last_diff.foo.2.bar": float64(1.0)}
+	stat := map[string]interface{}{"foo.1.bar": float64(1000)}
+	lastStat := map[string]interface{}{"foo.1.bar": float64(500), ".last_diff.foo.1.bar": float64(2.0)}
 	now := time.Unix(1437227240, 0)
 	lastTime := now.Add(-time.Duration(60) * time.Second)
 	mp.formatValuesWithWildcard(prefix, metric, &stat, &lastStat, now, lastTime)
 
 	// Output:
 	// foo.1.bar	1000.000000	1437227240
-	// foo.2.bar	2000.000000	1437227240
 }
 
 func ExampleFormatValuesWithWildcardAstarisk() {
@@ -202,14 +227,13 @@ func ExampleFormatValuesWithWildcardAstarisk() {
 	prefix := "foo"
 	metric := Metrics{Name: "*", Label: "Get", Diff: true, Type: "uint64"}
 	stat := map[string]interface{}{"foo.1": uint64(1000), "foo.2": uint64(2000)}
-	lastStat := map[string]interface{}{"foo.1": uint64(500), ".last_diff.foo.1": float64(2.0), "foo.2": uint64(1000), ".last_diff.foo.2": float64(1.0)}
+	lastStat := map[string]interface{}{"foo.1": uint64(500), ".last_diff.foo.1": float64(2.0)}
 	now := time.Unix(1437227240, 0)
 	lastTime := now.Add(-time.Duration(60) * time.Second)
 	mp.formatValuesWithWildcard(prefix, metric, &stat, &lastStat, now, lastTime)
 
 	// Output:
 	// foo.1	500.000000	1437227240
-	// foo.2	1000.000000	1437227240
 }
 
 // an example implementation


### PR DESCRIPTION
Mackerel API now supports wild characters, '#' and '*' for metric names.
This pull request make the helper support these characters.
