### PR TITLE
Avoid recognizing counter overflow when diff value is zero

### DIFF
--- a/mackerel-plugin.go
+++ b/mackerel-plugin.go
@@ -120,7 +120,7 @@ func (h *MackerelPlugin) calcDiffUint32(value uint32, now time.Time, lastValue u
 
 	diff := float64((value-lastValue)*60) / float64(diffTime)
 
-	if lastValue < value || diff < lastDiff*10 {
+	if lastValue <= value || diff < lastDiff*10 {
 		return diff, nil
 	}
 	return 0.0, errors.New("Counter seems to be reseted.")
@@ -135,7 +135,7 @@ func (h *MackerelPlugin) calcDiffUint64(value uint64, now time.Time, lastValue u
 
 	diff := float64((value-lastValue)*60) / float64(diffTime)
 
-	if lastValue < value || diff < lastDiff*10 {
+	if lastValue <= value || diff < lastDiff*10 {
 		return diff, nil
 	}
 	return 0.0, errors.New("Counter seems to be reseted.")

--- a/mackerel-plugin.go
+++ b/mackerel-plugin.go
@@ -123,7 +123,7 @@ func (h *MackerelPlugin) calcDiffUint32(value uint32, now time.Time, lastValue u
 	if lastValue <= value || diff < lastDiff*10 {
 		return diff, nil
 	}
-	return 0.0, errors.New("Counter seems to be reseted.")
+	return 0.0, errors.New("Counter seems to be reset.")
 
 }
 
@@ -138,7 +138,7 @@ func (h *MackerelPlugin) calcDiffUint64(value uint64, now time.Time, lastValue u
 	if lastValue <= value || diff < lastDiff*10 {
 		return diff, nil
 	}
-	return 0.0, errors.New("Counter seems to be reseted.")
+	return 0.0, errors.New("Counter seems to be reset.")
 }
 
 func (h *MackerelPlugin) Tempfilename() string {


### PR DESCRIPTION
If Type of metrics is uint64 or uint32 and Diff is true, the helper check counter overflow.
But even when differential value is zero, it recognizes counter overflow occured, and says 'Counter seems to be reseted.'
