### PR TITLE
add new interface `PluginWithPrefix`

### DIFF
--- a/mackerel-plugin.go
+++ b/mackerel-plugin.go
@@ -312,10 +312,16 @@ type GraphDef struct {
 	Graphs map[string]Graphs `json:"graphs"`
 }
 
+func title(s string) string {
+	r := strings.NewReplacer(".", " ", "_", " ")
+	return strings.Title(r.Replace(s))
+}
+
 func (h *MackerelPlugin) OutputDefinitions() {
 	fmt.Println("# mackerel-agent-plugin")
 	graphs := make(map[string]Graphs)
 	for key, graph := range h.GraphDefinition() {
+		g := graph
 		k := key
 		if p, ok := h.Plugin.(PluginWithPrefix); ok {
 			prefix := p.GetMetricKeyPrefix()
@@ -325,7 +331,18 @@ func (h *MackerelPlugin) OutputDefinitions() {
 				k = prefix + "." + k
 			}
 		}
-		graphs[k] = graph
+		if g.Label == "" {
+			g.Label = title(k)
+		}
+		metrics := []Metrics{}
+		for _, v := range g.Metrics {
+			if v.Label == "" {
+				v.Label = title(v.Name)
+			}
+			metrics = append(metrics, v)
+		}
+		g.Metrics = metrics
+		graphs[k] = g
 	}
 	var graphdef GraphDef
 	graphdef.Graphs = graphs

--- a/mackerel-plugin.go
+++ b/mackerel-plugin.go
@@ -34,13 +34,18 @@ type Plugin interface {
 	GraphDefinition() map[string]Graphs
 }
 
+type PluginWithPrefix interface {
+	Plugin
+	GetPrefix() string
+}
+
 type MackerelPlugin struct {
 	Plugin
 	Tempfile string
 }
 
 func NewMackerelPlugin(plugin Plugin) MackerelPlugin {
-	mp := MackerelPlugin{plugin, "/tmp/mackerel-plugin-default"}
+	mp := MackerelPlugin{Plugin: plugin}
 	return mp
 }
 
@@ -147,6 +152,13 @@ func (h *MackerelPlugin) calcDiffUint64(value uint64, now time.Time, lastValue u
 }
 
 func (h *MackerelPlugin) Tempfilename() string {
+	if h.Tempfile == "" {
+		prefix := "default"
+		if p, ok := h.Plugin.(PluginWithPrefix); ok {
+			prefix = p.GetPrefix()
+		}
+		h.Tempfile = fmt.Sprintf("/tmp/mackerel-plugin-%s", prefix)
+	}
 	return h.Tempfile
 }
 

--- a/mackerel-plugin.go
+++ b/mackerel-plugin.go
@@ -42,11 +42,29 @@ type PluginWithPrefix interface {
 type MackerelPlugin struct {
 	Plugin
 	Tempfile string
+	diff     *bool
 }
 
 func NewMackerelPlugin(plugin Plugin) MackerelPlugin {
 	mp := MackerelPlugin{Plugin: plugin}
 	return mp
+}
+
+func (h *MackerelPlugin) hasDiff() bool {
+	if h.diff == nil {
+		diff := false
+		h.diff = &diff
+	DiffCheck:
+		for _, graph := range h.GraphDefinition() {
+			for _, metric := range graph.Metrics {
+				if metric.Diff {
+					*h.diff = true
+					break DiffCheck
+				}
+			}
+		}
+	}
+	return *h.diff
 }
 
 func (h *MackerelPlugin) printValue(w io.Writer, key string, value interface{}, now time.Time) {

--- a/mackerel-plugin.go
+++ b/mackerel-plugin.go
@@ -36,7 +36,7 @@ type Plugin interface {
 
 type PluginWithPrefix interface {
 	Plugin
-	GetPrefix() string
+	GetMetricKeyPrefix() string
 }
 
 type MackerelPlugin struct {
@@ -179,7 +179,7 @@ func (h *MackerelPlugin) Tempfilename() string {
 	if h.Tempfile == "" {
 		prefix := "default"
 		if p, ok := h.Plugin.(PluginWithPrefix); ok {
-			prefix = p.GetPrefix()
+			prefix = p.GetMetricKeyPrefix()
 		}
 		h.Tempfile = fmt.Sprintf("/tmp/mackerel-plugin-%s", prefix)
 	}
@@ -245,7 +245,7 @@ func (h *MackerelPlugin) formatValues(prefix string, metric Metrics, stat *map[s
 
 	metricNames := []string{}
 	if p, ok := h.Plugin.(PluginWithPrefix); ok {
-		metricNames = append(metricNames, p.GetPrefix())
+		metricNames = append(metricNames, p.GetMetricKeyPrefix())
 	}
 	if len(prefix) > 0 {
 		metricNames = append(metricNames, prefix)
@@ -318,7 +318,7 @@ func (h *MackerelPlugin) OutputDefinitions() {
 	for key, graph := range h.GraphDefinition() {
 		k := key
 		if p, ok := h.Plugin.(PluginWithPrefix); ok {
-			prefix := p.GetPrefix()
+			prefix := p.GetMetricKeyPrefix()
 			if k == "" {
 				k = prefix
 			} else {

--- a/mackerel-plugin.go
+++ b/mackerel-plugin.go
@@ -318,7 +318,12 @@ func (h *MackerelPlugin) OutputDefinitions() {
 	for key, graph := range h.GraphDefinition() {
 		k := key
 		if p, ok := h.Plugin.(PluginWithPrefix); ok {
-			k = strings.Join([]string{p.GetPrefix(), k}, ".")
+			prefix := p.GetPrefix()
+			if k == "" {
+				k = prefix
+			} else {
+				k = prefix + "." + k
+			}
 		}
 		graphs[k] = graph
 	}

--- a/mackerel-plugin.go
+++ b/mackerel-plugin.go
@@ -83,6 +83,9 @@ func (h *MackerelPlugin) printValue(w io.Writer, key string, value interface{}, 
 }
 
 func (h *MackerelPlugin) fetchLastValues() (map[string]interface{}, time.Time, error) {
+	if !h.hasDiff() {
+		return nil, time.Unix(0, 0), nil
+	}
 	lastTime := time.Now()
 
 	f, err := os.Open(h.Tempfilename())
@@ -110,6 +113,9 @@ func (h *MackerelPlugin) fetchLastValues() (map[string]interface{}, time.Time, e
 }
 
 func (h *MackerelPlugin) saveValues(values map[string]interface{}, now time.Time) error {
+	if !h.hasDiff() {
+		return nil
+	}
 	f, err := os.Create(h.Tempfilename())
 	if err != nil {
 		return err

--- a/mackerel-plugin_test.go
+++ b/mackerel-plugin_test.go
@@ -350,8 +350,7 @@ func TestToFloat64(t *testing.T) {
 	}
 }
 
-type testP struct {
-}
+type testP struct{}
 
 func (t testP) FetchMetrics() (map[string]interface{}, error) {
 	return nil, nil
@@ -370,5 +369,49 @@ func TestPluginWithPrefix(t *testing.T) {
 	expect := "/tmp/mackerel-plugin-testP"
 	if p.Tempfilename() != expect {
 		t.Errorf("p.Tempfilename() should be %s, but: %s", expect, p.Tempfilename())
+	}
+}
+
+type testPHasDiff struct{}
+
+func (t testPHasDiff) FetchMetrics() (map[string]interface{}, error) {
+	return nil, nil
+}
+
+func (t testPHasDiff) GraphDefinition() map[string]Graphs {
+	return map[string](Graphs){
+		"hoge": Graphs{
+			Metrics: [](Metrics){
+				Metrics{Name: "hoge1", Label: "hoge1", Diff: true},
+			},
+		},
+	}
+}
+
+type testPHasntDiff struct{}
+
+func (t testPHasntDiff) FetchMetrics() (map[string]interface{}, error) {
+	return nil, nil
+}
+
+func (t testPHasntDiff) GraphDefinition() map[string]Graphs {
+	return map[string](Graphs){
+		"hoge": Graphs{
+			Metrics: [](Metrics){
+				Metrics{Name: "hoge1", Label: "hoge1"},
+			},
+		},
+	}
+}
+
+func TestPluginHasDiff(t *testing.T) {
+	pHasDiff := NewMackerelPlugin(testPHasDiff{})
+	if !pHasDiff.hasDiff() {
+		t.Errorf("something went wrong")
+	}
+
+	pHasntDiff := NewMackerelPlugin(testPHasntDiff{})
+	if pHasntDiff.hasDiff() {
+		t.Errorf("something went wrong")
 	}
 }

--- a/mackerel-plugin_test.go
+++ b/mackerel-plugin_test.go
@@ -349,3 +349,26 @@ func TestToFloat64(t *testing.T) {
 		t.Errorf("toFloat64(string) returns incorrect value: %v expected to be %v", ret, float64(100))
 	}
 }
+
+type testP struct {
+}
+
+func (t testP) FetchMetrics() (map[string]interface{}, error) {
+	return nil, nil
+}
+
+func (t testP) GraphDefinition() map[string]Graphs {
+	return nil
+}
+
+func (t testP) GetPrefix() string {
+	return "testP"
+}
+
+func TestPluginWithPrefix(t *testing.T) {
+	p := NewMackerelPlugin(testP{})
+	expect := "/tmp/mackerel-plugin-testP"
+	if p.Tempfilename() != expect {
+		t.Errorf("p.Tempfilename() should be %s, but: %s", expect, p.Tempfilename())
+	}
+}

--- a/mackerel-plugin_test.go
+++ b/mackerel-plugin_test.go
@@ -353,11 +353,26 @@ func TestToFloat64(t *testing.T) {
 type testP struct{}
 
 func (t testP) FetchMetrics() (map[string]interface{}, error) {
-	return nil, nil
+	ret := make(map[string]interface{})
+	ret["bar"] = 15
+	return ret, nil
 }
 
 func (t testP) GraphDefinition() map[string]Graphs {
-	return nil
+	return map[string](Graphs){
+		"": Graphs{
+			Unit: "integer",
+			Metrics: [](Metrics){
+				Metrics{Name: "bar"},
+			},
+		},
+		"fuga": Graphs{
+			Unit: "float",
+			Metrics: [](Metrics){
+				Metrics{Name: "baz"},
+			},
+		},
+	}
 }
 
 func (t testP) GetPrefix() string {
@@ -370,6 +385,15 @@ func TestPluginWithPrefix(t *testing.T) {
 	if p.Tempfilename() != expect {
 		t.Errorf("p.Tempfilename() should be %s, but: %s", expect, p.Tempfilename())
 	}
+}
+
+func ExamplePluginWithPrefixOutputDefinitions() {
+	helper := NewMackerelPlugin(testP{})
+	helper.OutputDefinitions()
+
+	// Output:
+	// # mackerel-agent-plugin
+	// {"graphs":{"testP":{"label":"","unit":"integer","metrics":[{"name":"bar","label":"","type":"","stacked":false,"scale":0}]},"testP.fuga":{"label":"","unit":"float","metrics":[{"name":"baz","label":"","type":"","stacked":false,"scale":0}]}}}
 }
 
 type testPHasDiff struct{}

--- a/mackerel-plugin_test.go
+++ b/mackerel-plugin_test.go
@@ -354,7 +354,8 @@ type testP struct{}
 
 func (t testP) FetchMetrics() (map[string]interface{}, error) {
 	ret := make(map[string]interface{})
-	ret["bar"] = 15
+	ret["bar"] = 15.0
+	ret["baz"] = 18.0
 	return ret, nil
 }
 
@@ -394,6 +395,34 @@ func ExamplePluginWithPrefixOutputDefinitions() {
 	// Output:
 	// # mackerel-agent-plugin
 	// {"graphs":{"testP":{"label":"","unit":"integer","metrics":[{"name":"bar","label":"","type":"","stacked":false,"scale":0}]},"testP.fuga":{"label":"","unit":"float","metrics":[{"name":"baz","label":"","type":"","stacked":false,"scale":0}]}}}
+}
+
+func ExamplePluginWithPrefixOutputValues() {
+	helper := NewMackerelPlugin(testP{})
+	stat, _ := helper.FetchMetrics()
+	key := ""
+	metric := helper.GraphDefinition()[key].Metrics[0]
+	var lastStat map[string]interface{} = nil
+	now := time.Unix(1437227240, 0)
+	lastTime := time.Unix(0, 0)
+	helper.formatValues(key, metric, &stat, &lastStat, now, lastTime)
+
+	// Output:
+	// testP.bar	15.000000	1437227240
+}
+
+func ExamplePluginWithPrefixOutputValues2() {
+	helper := NewMackerelPlugin(testP{})
+	stat, _ := helper.FetchMetrics()
+	key := "fuga"
+	metric := helper.GraphDefinition()[key].Metrics[0]
+	var lastStat map[string]interface{} = nil
+	now := time.Unix(1437227240, 0)
+	lastTime := time.Unix(0, 0)
+	helper.formatValues(key, metric, &stat, &lastStat, now, lastTime)
+
+	// Output:
+	// testP.fuga.baz	18.000000	1437227240
 }
 
 type testPHasDiff struct{}

--- a/mackerel-plugin_test.go
+++ b/mackerel-plugin_test.go
@@ -394,7 +394,7 @@ func ExamplePluginWithPrefixOutputDefinitions() {
 
 	// Output:
 	// # mackerel-agent-plugin
-	// {"graphs":{"testP":{"label":"","unit":"integer","metrics":[{"name":"bar","label":"","type":"","stacked":false,"scale":0}]},"testP.fuga":{"label":"","unit":"float","metrics":[{"name":"baz","label":"","type":"","stacked":false,"scale":0}]}}}
+	// {"graphs":{"testP":{"label":"TestP","unit":"integer","metrics":[{"name":"bar","label":"Bar","type":"","stacked":false,"scale":0}]},"testP.fuga":{"label":"TestP Fuga","unit":"float","metrics":[{"name":"baz","label":"Baz","type":"","stacked":false,"scale":0}]}}}
 }
 
 func ExamplePluginWithPrefixOutputValues() {

--- a/mackerel-plugin_test.go
+++ b/mackerel-plugin_test.go
@@ -376,7 +376,7 @@ func (t testP) GraphDefinition() map[string]Graphs {
 	}
 }
 
-func (t testP) GetPrefix() string {
+func (t testP) GetMetricKeyPrefix() string {
 	return "testP"
 }
 


### PR DESCRIPTION
`PluginWithPrefix` interface is extended from `mp.Plugin`.

It has the method `GetMetricKeyPrefix` which returns string, that is unique
metric key prefix of plugins in a mackerel-agent.conf.

It resolves the problem that some plugins which we can't specify more than one
in mackerel-agent.conf because of prefix conflict.

```
# e.g. It doesn't work!
[mackerel.plugin.apache2]
/usr/local/bin/mackerel-plugin-apache2

[mackerel.plugin.apache2-other]
/usr/local/bin/mackerel-plugin-apache2 -p 8088
```

For using it, it is recommended to implement the `-metric-key-prefix` cli option
which value is used as the return value of the `GetMetricKeyPrefix` in plugins.

And another, `PluginWithPrefix` do them.
- Automatically determine the tempfile
  - Plugin authors need not to care tempfile location.
- Automatically add metric key prefix into metric keys of `OutputValues()` and 
  `OutputDefinitions()`.
- Automatically fill the Labels if these are empty.
- Don't create tempfile if the plugin don't have "diff" metrics.

By using `PluginWithPrefix`, plugin authors can create plugins more easily.
