### PR TITLE
go vet: mackerel-plugin.go:267: no formatting directive in Fatalf call

### DIFF
--- a/mackerel-plugin.go
+++ b/mackerel-plugin.go
@@ -264,7 +264,7 @@ func (h *MackerelPlugin) OutputValues() {
 
 	err = h.saveValues(stat, now)
 	if err != nil {
-		log.Fatalf("saveValues: ", err)
+		log.Fatalln("saveValues: ", err)
 	}
 }
 


### PR DESCRIPTION
$ go vet ./...
mackerel-plugin.go:267: no formatting directive in Fatalf call
