### PR TITLE
change definition of PluginWithPrefix interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ A plugin must implement this interface and the `main` method.
 type PluginWithPrefix interface {
 	FetchMetrics() (map[string]interface{}, error)
 	GraphDefinition() map[string]Graphs
-	GetMetricKeyPrefix() string
+	MetricKeyPrefix() string
 }
 ```
 

--- a/mackerel-plugin.go
+++ b/mackerel-plugin.go
@@ -42,7 +42,7 @@ type Plugin interface {
 // PluginWithPrefix is recommended interface
 type PluginWithPrefix interface {
 	Plugin
-	GetMetricKeyPrefix() string
+	MetricKeyPrefix() string
 }
 
 // MackerelPlugin is for mackerel-agent-plugin
@@ -187,7 +187,7 @@ func (h *MackerelPlugin) tempfilename() string {
 	if h.Tempfile == "" {
 		prefix := "default"
 		if p, ok := h.Plugin.(PluginWithPrefix); ok {
-			prefix = p.GetMetricKeyPrefix()
+			prefix = p.MetricKeyPrefix()
 		}
 		filename := fmt.Sprintf("mackerel-plugin-%s", prefix)
 		h.Tempfile = filepath.Join(os.TempDir(), filename)
@@ -257,7 +257,7 @@ func (h *MackerelPlugin) formatValues(prefix string, metric Metrics, stat *map[s
 
 	metricNames := []string{}
 	if p, ok := h.Plugin.(PluginWithPrefix); ok {
-		metricNames = append(metricNames, p.GetMetricKeyPrefix())
+		metricNames = append(metricNames, p.MetricKeyPrefix())
 	}
 	if len(prefix) > 0 {
 		metricNames = append(metricNames, prefix)
@@ -340,7 +340,7 @@ func (h *MackerelPlugin) OutputDefinitions() {
 		g := graph
 		k := key
 		if p, ok := h.Plugin.(PluginWithPrefix); ok {
-			prefix := p.GetMetricKeyPrefix()
+			prefix := p.MetricKeyPrefix()
 			if k == "" {
 				k = prefix
 			} else {

--- a/mackerel-plugin_test.go
+++ b/mackerel-plugin_test.go
@@ -425,7 +425,7 @@ func (t testP) GraphDefinition() map[string]Graphs {
 	}
 }
 
-func (t testP) GetMetricKeyPrefix() string {
+func (t testP) MetricKeyPrefix() string {
 	return "testP"
 }
 


### PR DESCRIPTION
ref #15 
s/GetMetricKeyPrefix/MetricKeyPrefix/g

It is imcompatible change but `PluginWithPrefix` is still not used now.
