### PR TITLE
MACKEREL_PLUGIN_WORKDIR

### DIFF
--- a/mackerel-plugin.go
+++ b/mackerel-plugin.go
@@ -125,10 +125,6 @@ func (h *MackerelPlugin) saveValues(values map[string]interface{}, now time.Time
 		return nil
 	}
 	fname := h.tempfilename()
-	err := os.MkdirAll(filepath.Dir(fname), 0777)
-	if err != nil {
-		return err
-	}
 	f, err := os.Create(fname)
 	if err != nil {
 		return err

--- a/mackerel-plugin.go
+++ b/mackerel-plugin.go
@@ -124,7 +124,12 @@ func (h *MackerelPlugin) saveValues(values map[string]interface{}, now time.Time
 	if !h.hasDiff() {
 		return nil
 	}
-	f, err := os.Create(h.tempfilename())
+	fname := h.tempfilename()
+	err := os.MkdirAll(filepath.Dir(fname), 0777)
+	if err != nil {
+		return err
+	}
+	f, err := os.Create(fname)
 	if err != nil {
 		return err
 	}

--- a/mackerel-plugin.go
+++ b/mackerel-plugin.go
@@ -190,7 +190,11 @@ func (h *MackerelPlugin) tempfilename() string {
 			prefix = p.MetricKeyPrefix()
 		}
 		filename := fmt.Sprintf("mackerel-plugin-%s", prefix)
-		h.Tempfile = filepath.Join(os.TempDir(), filename)
+		dir := os.Getenv("MACKEREL_PLUGIN_WORKDIR")
+		if dir == "" {
+			dir = os.TempDir()
+		}
+		h.Tempfile = filepath.Join(dir, filename)
 	}
 	return h.Tempfile
 }


### PR DESCRIPTION
If env `MACKEREL_PLUGIN_WORKDIR` is set, use it for the `tmpfile`'s location.
