### PR TITLE
Generate default tempfile filename using os.Args[0]

### DIFF
--- a/mackerel-plugin.go
+++ b/mackerel-plugin.go
@@ -96,7 +96,7 @@ func (h *MackerelPlugin) fetchLastValues() (map[string]interface{}, time.Time, e
 	}
 	lastTime := time.Now()
 
-	f, err := os.Open(h.tempfilePath())
+	f, err := os.Open(h.tempfilename())
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, lastTime, nil
@@ -124,7 +124,7 @@ func (h *MackerelPlugin) saveValues(values map[string]interface{}, now time.Time
 	if !h.hasDiff() {
 		return nil
 	}
-	fname := h.tempfilePath()
+	fname := h.tempfilename()
 	f, err := os.Create(fname)
 	if err != nil {
 		return err
@@ -184,7 +184,7 @@ func (h *MackerelPlugin) calcDiffUint64(value uint64, now time.Time, lastValue u
 	return 0.0, errors.New("Counter seems to be reset.")
 }
 
-func (h *MackerelPlugin) tempfilePath() string {
+func (h *MackerelPlugin) tempfilename() string {
 	if h.Tempfile == "" {
 		h.Tempfile = h.generateTempfilePath(os.Args[0])
 	}

--- a/mackerel-plugin.go
+++ b/mackerel-plugin.go
@@ -196,7 +196,9 @@ func (h *MackerelPlugin) generateTempfilePath(path string) string {
 	if p, ok := h.Plugin.(PluginWithPrefix); ok {
 		prefix = p.MetricKeyPrefix()
 	} else {
-		prefix = filepath.Base(path)
+		name := filepath.Base(path)
+		var sanitizeReg = regexp.MustCompile(`[^A-Za-z0-9_.-]`)
+		prefix = sanitizeReg.ReplaceAllString(name, "_")
 	}
 	filename := fmt.Sprintf("mackerel-plugin-%s", prefix)
 	dir := os.Getenv("MACKEREL_PLUGIN_WORKDIR")

--- a/mackerel-plugin.go
+++ b/mackerel-plugin.go
@@ -186,7 +186,7 @@ func (h *MackerelPlugin) calcDiffUint64(value uint64, now time.Time, lastValue u
 
 func (h *MackerelPlugin) tempfilename() string {
 	if h.Tempfile == "" {
-		prefix := "default"
+		prefix := filepath.Base(os.Args[0])
 		if p, ok := h.Plugin.(PluginWithPrefix); ok {
 			prefix = p.MetricKeyPrefix()
 		}

--- a/mackerel-plugin.go
+++ b/mackerel-plugin.go
@@ -191,14 +191,15 @@ func (h *MackerelPlugin) tempfilename() string {
 	return h.Tempfile
 }
 
+var tempfileSanitizeReg = regexp.MustCompile(`[^A-Za-z0-9_.-]`)
+
 func (h *MackerelPlugin) generateTempfilePath(path string) string {
 	var prefix string
 	if p, ok := h.Plugin.(PluginWithPrefix); ok {
 		prefix = p.MetricKeyPrefix()
 	} else {
 		name := filepath.Base(path)
-		var sanitizeReg = regexp.MustCompile(`[^A-Za-z0-9_.-]`)
-		prefix = strings.TrimPrefix(sanitizeReg.ReplaceAllString(name, "_"), "mackerel-plugin-")
+		prefix = strings.TrimPrefix(tempfileSanitizeReg.ReplaceAllString(name, "_"), "mackerel-plugin-")
 	}
 	filename := fmt.Sprintf("mackerel-plugin-%s", prefix)
 	dir := os.Getenv("MACKEREL_PLUGIN_WORKDIR")

--- a/mackerel-plugin.go
+++ b/mackerel-plugin.go
@@ -198,7 +198,7 @@ func (h *MackerelPlugin) generateTempfilePath(path string) string {
 	} else {
 		name := filepath.Base(path)
 		var sanitizeReg = regexp.MustCompile(`[^A-Za-z0-9_.-]`)
-		prefix = sanitizeReg.ReplaceAllString(name, "_")
+		prefix = strings.TrimPrefix(sanitizeReg.ReplaceAllString(name, "_"), "mackerel-plugin-")
 	}
 	filename := fmt.Sprintf("mackerel-plugin-%s", prefix)
 	dir := os.Getenv("MACKEREL_PLUGIN_WORKDIR")

--- a/mackerel-plugin_test.go
+++ b/mackerel-plugin_test.go
@@ -430,20 +430,38 @@ func (t testP) MetricKeyPrefix() string {
 	return "testP"
 }
 
-func TestPluginWithPrefix(t *testing.T) {
-	p := NewMackerelPlugin(testP{})
-	expect := filepath.Join(os.TempDir(), "mackerel-plugin-testP")
-	if p.tempfilename() != expect {
-		t.Errorf("p.tempfilename() should be %s, but: %s", expect, p.tempfilename())
-	}
-}
-
 func TestDefaultTempfile(t *testing.T) {
 	var p MackerelPlugin
 	filename := filepath.Base(os.Args[0])
 	expect := filepath.Join(os.TempDir(), fmt.Sprintf("mackerel-plugin-%s", filename))
-	if p.tempfilename() != expect {
-		t.Errorf("p.tempfilename() should be %s, but: %s", expect, p.tempfilename())
+	if p.tempfilePath() != expect {
+		t.Errorf("p.tempfilePath() should be %s, but: %s", expect, p.tempfilePath())
+	}
+
+	pPrefix := NewMackerelPlugin(testP{})
+	expectForPrefix := filepath.Join(os.TempDir(), "mackerel-plugin-testP")
+	if pPrefix.tempfilePath() != expectForPrefix {
+		t.Errorf("pPrefix.tempfilePath() should be %s, but: %s", expectForPrefix, pPrefix.tempfilePath())
+	}
+}
+
+func TestTempfilenameFromExecutableFilePath(t *testing.T) {
+	var p MackerelPlugin
+
+	wd, _ := os.Getwd()
+	// not PluginWithPrefix, regular filename
+	expect1 := filepath.Join(os.TempDir(), "mackerel-plugin-foobar")
+	filename1 := p.generateTempfilePath(filepath.Join(wd, "foobar"))
+	if filename1 != expect1 {
+		t.Errorf("p.generateTempfilePath() should be %s, but: %s", expect1, filename1)
+	}
+
+	// PluginWithPrefix ignores current filename
+	pPrefix := NewMackerelPlugin(testP{})
+	expectForPrefix := filepath.Join(os.TempDir(), "mackerel-plugin-testP")
+	filenameForPrefix := pPrefix.generateTempfilePath(filepath.Join(wd, "foo"))
+	if filenameForPrefix != expectForPrefix {
+		t.Errorf("pPrefix.generateTempfilePath() should be %s, but: %s", expectForPrefix, filenameForPrefix)
 	}
 }
 

--- a/mackerel-plugin_test.go
+++ b/mackerel-plugin_test.go
@@ -456,6 +456,13 @@ func TestTempfilenameFromExecutableFilePath(t *testing.T) {
 		t.Errorf("p.generateTempfilePath() should be %s, but: %s", expect1, filename1)
 	}
 
+	// not PluginWithPrefix, contains some characters to be sanitized
+	expect2 := filepath.Join(os.TempDir(), "mackerel-plugin-some_sanitized_name_1.2")
+	filename2 := p.generateTempfilePath(filepath.Join(wd, "some sanitized:name+1.2"))
+	if filename2 != expect2 {
+		t.Errorf("p.generateTempfilePath() should be %s, but: %s", expect2, filename2)
+	}
+
 	// PluginWithPrefix ignores current filename
 	pPrefix := NewMackerelPlugin(testP{})
 	expectForPrefix := filepath.Join(os.TempDir(), "mackerel-plugin-testP")

--- a/mackerel-plugin_test.go
+++ b/mackerel-plugin_test.go
@@ -463,6 +463,13 @@ func TestTempfilenameFromExecutableFilePath(t *testing.T) {
 		t.Errorf("p.generateTempfilePath() should be %s, but: %s", expect2, filename2)
 	}
 
+	// not PluginWithPrefix, begins with "mackerel-plugin-"
+	expect3 := filepath.Join(os.TempDir(), "mackerel-plugin-trimmed")
+	filename3 := p.generateTempfilePath(filepath.Join(wd, "mackerel-plugin-trimmed"))
+	if filename3 != expect3 {
+		t.Errorf("p.generateTempfilePath() should be %s, but: %s", expect3, filename3)
+	}
+
 	// PluginWithPrefix ignores current filename
 	pPrefix := NewMackerelPlugin(testP{})
 	expectForPrefix := filepath.Join(os.TempDir(), "mackerel-plugin-testP")

--- a/mackerel-plugin_test.go
+++ b/mackerel-plugin_test.go
@@ -434,14 +434,14 @@ func TestDefaultTempfile(t *testing.T) {
 	var p MackerelPlugin
 	filename := filepath.Base(os.Args[0])
 	expect := filepath.Join(os.TempDir(), fmt.Sprintf("mackerel-plugin-%s", filename))
-	if p.tempfilePath() != expect {
-		t.Errorf("p.tempfilePath() should be %s, but: %s", expect, p.tempfilePath())
+	if p.tempfilename() != expect {
+		t.Errorf("p.tempfilename() should be %s, but: %s", expect, p.tempfilename())
 	}
 
 	pPrefix := NewMackerelPlugin(testP{})
 	expectForPrefix := filepath.Join(os.TempDir(), "mackerel-plugin-testP")
-	if pPrefix.tempfilePath() != expectForPrefix {
-		t.Errorf("pPrefix.tempfilePath() should be %s, but: %s", expectForPrefix, pPrefix.tempfilePath())
+	if pPrefix.tempfilename() != expectForPrefix {
+		t.Errorf("pPrefix.tempfilename() should be %s, but: %s", expectForPrefix, pPrefix.tempfilename())
 	}
 }
 

--- a/mackerel-plugin_test.go
+++ b/mackerel-plugin_test.go
@@ -437,6 +437,14 @@ func TestPluginWithPrefix(t *testing.T) {
 	}
 }
 
+func TestDefaultTempfile(t *testing.T) {
+	var p MackerelPlugin
+	expect := filepath.Join(os.TempDir(), "mackerel-plugin-default")
+	if p.tempfilename() != expect {
+		t.Errorf("p.tempfilename() should be %s, but: %s", expect, p.tempfilename())
+	}
+}
+
 func ExamplePluginWithPrefixOutputDefinitions() {
 	helper := NewMackerelPlugin(testP{})
 	helper.OutputDefinitions()

--- a/mackerel-plugin_test.go
+++ b/mackerel-plugin_test.go
@@ -2,6 +2,7 @@ package mackerelplugin
 
 import (
 	"bytes"
+	"fmt"
 	"math"
 	"os"
 	"path/filepath"
@@ -439,7 +440,8 @@ func TestPluginWithPrefix(t *testing.T) {
 
 func TestDefaultTempfile(t *testing.T) {
 	var p MackerelPlugin
-	expect := filepath.Join(os.TempDir(), "mackerel-plugin-default")
+	filename := filepath.Base(os.Args[0])
+	expect := filepath.Join(os.TempDir(), fmt.Sprintf("mackerel-plugin-%s", filename))
 	if p.tempfilename() != expect {
 		t.Errorf("p.tempfilename() should be %s, but: %s", expect, p.tempfilename())
 	}


### PR DESCRIPTION
Related: https://github.com/mackerelio/mackerel-agent-plugins/pull/260
# Current behavior
- For plugins implementing `PluginWithPrefix`, default Tempfile filename is `mackerel-plugin-{prefix}`
- For plugins NOT implementing `PluginWithPrefix`, default Tempfile filename is `mackerel-plugin-default`

The latter default filename `mackerel-plugin-default` is not good one, because it's not unique.
if multiple plugins using same Tempfile work at the same time, they all try to use `mackerel-plugin-default` and may conflict.
To avoid this, every plugin has to set default Tempfile filename, though this parameter is said to be optional.
# Changes I want to introduce

I'd like to change default Tempfile filename for plugins NOT implementing `PluginWithPrefix` to generate from their filename, like `mackerel-plugin-{filename}`.
With this change, Tempfile will be unique for plugins with different filenames, in many cases this is fine.
