### PR TITLE
Add SetTempfileWithBaseName()

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,12 +85,12 @@ If this field is omitted, the filename of the temporaty file is automatically ge
 
 mackerel-agent's plugins should place its Tempfile under `os.Getenv("MACKEREL_PLUGIN_WORKDIR")` unless specified explicitly.
 Since this helper handles the environmental value, it's recommended not to set default Tempfile path.
-But if a plugin wants to set default Tempfile filename by itself, use `MackerelPlugin.SetTempfileWithBaseName()`, which sets Tempfile path considering the environmental value.
+But if a plugin wants to set default Tempfile filename by itself, use `MackerelPlugin.SetTempfileByBasename()`, which sets Tempfile path considering the environmental value.
 
 ```go
   helper.Tempfile = *optTempfile
   if optTempfile == nil {
-    helper.SetTempfileWithBaseName("YOUR_DEFAULT_FILENAME")
+    helper.SetTempfileByBasename("YOUR_DEFAULT_FILENAME")
   }
 ```
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ If `Type` of metrics is `uint64` or `uint32` and `Diff` is true, the helper chec
 When differential value is negative, overflow or counter reset may be occurred.
 If the differential value is ten-times above last value, the helper judge this is counter reset, not counter overflow, then the helper set value is unknown. If not, the helper recognizes counter overflow occurred.
 
+## Tempfile
+
+`MackerelPlugin` interface has `Tempfile` field. The tempfile is used to calc differences in metrics with `Diff: true`.
+If this field is kept empty, default Tempfile will be placed under `os.Getenv("MACKEREL_PLUGIN_WORKDIR")` or `os.Tempdir()` and its filename will be generated from plugin filename.
+mackerel-agent's plugin should place its Tempfile under `os.Getenv("MACKEREL_PLUGIN_WORKDIR")` unless specified explicitly. If plugin wants to set default Tempfile filename by itself, use `MackerelPlugin.GenerateTempfilePathWithBase()`.
+
 ## Method
 
 A plugin must implement this interface and the `main` method.

--- a/README.md
+++ b/README.md
@@ -79,8 +79,20 @@ If the differential value is ten-times above last value, the helper judge this i
 ## Tempfile
 
 `MackerelPlugin` interface has `Tempfile` field. The tempfile is used to calc differences in metrics with `Diff: true`.
-If this field is kept empty, default Tempfile will be placed under `os.Getenv("MACKEREL_PLUGIN_WORKDIR")` or `os.Tempdir()` and its filename will be generated from plugin filename.
-mackerel-agent's plugin should place its Tempfile under `os.Getenv("MACKEREL_PLUGIN_WORKDIR")` unless specified explicitly. If plugin wants to set default Tempfile filename by itself, use `MackerelPlugin.GenerateTempfilePathWithBase()`.
+If this field is empty, default Tempfile will be placed under `os.Getenv("MACKEREL_PLUGIN_WORKDIR")` or `os.Tempdir()` and its filename will be generated from plugin filename.
+
+### Default value of Tempfile
+
+mackerel-agent's plugins should place its Tempfile under `os.Getenv("MACKEREL_PLUGIN_WORKDIR")` unless specified explicitly.
+Since this helper handles the environmental value, it's recommended not to set default Tempfile path.
+But if a plugin wants to set default Tempfile filename by itself, use `MackerelPlugin.GenerateTempfilePathWithBase()`.
+
+```go
+  helper.Tempfile = *optTempfile
+  if optTempfile == nil {
+    helper.Tempfile = helper.GenerateTempfilePathWithBase("YOUR_DEFAULT_FILENAME")
+  }
+```
 
 ## Method
 

--- a/README.md
+++ b/README.md
@@ -78,14 +78,14 @@ If the differential value is ten-times above last value, the helper judge this i
 
 ## Tempfile
 
-`MackerelPlugin` interface has `Tempfile` field. The tempfile is used to calc differences in metrics with `Diff: true`.
+`MackerelPlugin` interface has `Tempfile` field. The Tempfile is used to calc differences in metrics with `Diff: true`.
 If this field is empty, default Tempfile will be placed under `os.Getenv("MACKEREL_PLUGIN_WORKDIR")` or `os.Tempdir()` and its filename will be generated from plugin filename.
 
 ### Default value of Tempfile
 
 mackerel-agent's plugins should place its Tempfile under `os.Getenv("MACKEREL_PLUGIN_WORKDIR")` unless specified explicitly.
 Since this helper handles the environmental value, it's recommended not to set default Tempfile path.
-But if a plugin wants to set default Tempfile filename by itself, use `MackerelPlugin.GenerateTempfilePathWithBase()`.
+But if a plugin wants to set default Tempfile filename by itself, use `MackerelPlugin.GenerateTempfilePathWithBase()`, which generates Tempfile path considering the environmental value.
 
 ```go
   helper.Tempfile = *optTempfile

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ If the differential value is ten-times above last value, the helper judge this i
 ## Tempfile
 
 `MackerelPlugin` interface has `Tempfile` field. The Tempfile is used to calc differences in metrics with `Diff: true`.
-If this field is empty, default Tempfile will be placed under `os.Getenv("MACKEREL_PLUGIN_WORKDIR")` or `os.Tempdir()` and its filename will be generated from plugin filename.
+If this field is empty, default Tempfile's filename will be generated from plugin filename.
 
 ### Default value of Tempfile
 

--- a/README.md
+++ b/README.md
@@ -78,8 +78,8 @@ If the differential value is ten-times above last value, the helper judge this i
 
 ## Tempfile
 
-`MackerelPlugin` interface has `Tempfile` field. The Tempfile is used to calc differences in metrics with `Diff: true`.
-If this field is empty, default Tempfile's filename will be generated from plugin filename.
+`MackerelPlugin` interface has `Tempfile` field. The Tempfile is used to calculate differences in metrics with `Diff: true`.
+If this field is omitted, the filename of the temporaty file is automatically generated from plugin filename.
 
 ### Default value of Tempfile
 

--- a/README.md
+++ b/README.md
@@ -85,12 +85,12 @@ If this field is empty, default Tempfile will be placed under `os.Getenv("MACKER
 
 mackerel-agent's plugins should place its Tempfile under `os.Getenv("MACKEREL_PLUGIN_WORKDIR")` unless specified explicitly.
 Since this helper handles the environmental value, it's recommended not to set default Tempfile path.
-But if a plugin wants to set default Tempfile filename by itself, use `MackerelPlugin.GenerateTempfilePathWithBase()`, which generates Tempfile path considering the environmental value.
+But if a plugin wants to set default Tempfile filename by itself, use `MackerelPlugin.SetTempfileWithBaseName()`, which sets Tempfile path considering the environmental value.
 
 ```go
   helper.Tempfile = *optTempfile
   if optTempfile == nil {
-    helper.Tempfile = helper.GenerateTempfilePathWithBase("YOUR_DEFAULT_FILENAME")
+    helper.SetTempfileWithBaseName("YOUR_DEFAULT_FILENAME")
   }
 ```
 

--- a/mackerel-plugin.go
+++ b/mackerel-plugin.go
@@ -195,9 +195,9 @@ func (h *MackerelPlugin) tempfilename() string {
 
 var tempfileSanitizeReg = regexp.MustCompile(`[^A-Za-z0-9_.-]`)
 
-// GenerateTempfilePathForWithBase generates Tempfile path with specified base.
-func (h *MackerelPlugin) GenerateTempfilePathWithBase(base string) string {
-	return filepath.Join(pluginutil.PluginWorkDir(), base)
+// SetTempfileWithBaseName sets Tempfile under proper directory with specified basename.
+func (h *MackerelPlugin) SetTempfileWithBaseName(base string) {
+	h.Tempfile = filepath.Join(pluginutil.PluginWorkDir(), base)
 }
 
 func (h *MackerelPlugin) generateTempfilePath(path string) string {

--- a/mackerel-plugin.go
+++ b/mackerel-plugin.go
@@ -193,6 +193,19 @@ func (h *MackerelPlugin) tempfilename() string {
 
 var tempfileSanitizeReg = regexp.MustCompile(`[^A-Za-z0-9_.-]`)
 
+func (h *MackerelPlugin) generateTempfileDir() string {
+	dir := os.Getenv("MACKEREL_PLUGIN_WORKDIR")
+	if dir == "" {
+		dir = os.TempDir()
+	}
+	return dir
+}
+
+// GenerateTempfilePathForWithBase generates Tempfile path with specified base.
+func (h *MackerelPlugin) GenerateTempfilePathWithBase(base string) string {
+	return filepath.Join(h.generateTempfileDir(), base)
+}
+
 func (h *MackerelPlugin) generateTempfilePath(path string) string {
 	var prefix string
 	if p, ok := h.Plugin.(PluginWithPrefix); ok {
@@ -202,11 +215,7 @@ func (h *MackerelPlugin) generateTempfilePath(path string) string {
 		prefix = strings.TrimPrefix(tempfileSanitizeReg.ReplaceAllString(name, "_"), "mackerel-plugin-")
 	}
 	filename := fmt.Sprintf("mackerel-plugin-%s", prefix)
-	dir := os.Getenv("MACKEREL_PLUGIN_WORKDIR")
-	if dir == "" {
-		dir = os.TempDir()
-	}
-	return filepath.Join(dir, filename)
+	return filepath.Join(h.generateTempfileDir(), filename)
 }
 
 func (h *MackerelPlugin) formatValues(prefix string, metric Metrics, stat *map[string]interface{}, lastStat *map[string]interface{}, now time.Time, lastTime time.Time) {

--- a/mackerel-plugin.go
+++ b/mackerel-plugin.go
@@ -13,6 +13,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/mackerelio/golib/pluginutil"
 )
 
 // Metrics represents definition of a metric
@@ -193,17 +195,9 @@ func (h *MackerelPlugin) tempfilename() string {
 
 var tempfileSanitizeReg = regexp.MustCompile(`[^A-Za-z0-9_.-]`)
 
-func (h *MackerelPlugin) generateTempfileDir() string {
-	dir := os.Getenv("MACKEREL_PLUGIN_WORKDIR")
-	if dir == "" {
-		dir = os.TempDir()
-	}
-	return dir
-}
-
 // GenerateTempfilePathForWithBase generates Tempfile path with specified base.
 func (h *MackerelPlugin) GenerateTempfilePathWithBase(base string) string {
-	return filepath.Join(h.generateTempfileDir(), base)
+	return filepath.Join(pluginutil.PluginWorkDir(), base)
 }
 
 func (h *MackerelPlugin) generateTempfilePath(path string) string {
@@ -215,7 +209,7 @@ func (h *MackerelPlugin) generateTempfilePath(path string) string {
 		prefix = strings.TrimPrefix(tempfileSanitizeReg.ReplaceAllString(name, "_"), "mackerel-plugin-")
 	}
 	filename := fmt.Sprintf("mackerel-plugin-%s", prefix)
-	return filepath.Join(h.generateTempfileDir(), filename)
+	return filepath.Join(pluginutil.PluginWorkDir(), filename)
 }
 
 func (h *MackerelPlugin) formatValues(prefix string, metric Metrics, stat *map[string]interface{}, lastStat *map[string]interface{}, now time.Time, lastTime time.Time) {

--- a/mackerel-plugin.go
+++ b/mackerel-plugin.go
@@ -195,8 +195,8 @@ func (h *MackerelPlugin) tempfilename() string {
 
 var tempfileSanitizeReg = regexp.MustCompile(`[^A-Za-z0-9_.-]`)
 
-// SetTempfileWithBaseName sets Tempfile under proper directory with specified basename.
-func (h *MackerelPlugin) SetTempfileWithBaseName(base string) {
+// SetTempfileByBasename sets Tempfile under proper directory with specified basename.
+func (h *MackerelPlugin) SetTempfileByBasename(base string) {
 	h.Tempfile = filepath.Join(pluginutil.PluginWorkDir(), base)
 }
 

--- a/mackerel-plugin_test.go
+++ b/mackerel-plugin_test.go
@@ -479,13 +479,13 @@ func TestTempfilenameFromExecutableFilePath(t *testing.T) {
 	}
 }
 
-func TestSetTempfileWithBaseName(t *testing.T) {
+func TestSetTempfileWithBasename(t *testing.T) {
 	var p MackerelPlugin
 
 	expect1 := filepath.Join(os.TempDir(), "my-super-tempfile")
-	p.SetTempfileWithBaseName("my-super-tempfile")
+	p.SetTempfileByBasename("my-super-tempfile")
 	if p.Tempfile != expect1 {
-		t.Errorf("p.SetTempfileWithBaseName() should set %s, but: %s", expect1, p.Tempfile)
+		t.Errorf("p.SetTempfileByBasename() should set %s, but: %s", expect1, p.Tempfile)
 	}
 
 	origDir := os.Getenv("MACKEREL_PLUGIN_WORKDIR")
@@ -493,9 +493,9 @@ func TestSetTempfileWithBaseName(t *testing.T) {
 	defer os.Setenv("MACKEREL_PLUGIN_WORKDIR", origDir)
 
 	expect2 := "/tmp/somewhere/my-great-tempfile"
-	p.SetTempfileWithBaseName("my-great-tempfile")
+	p.SetTempfileByBasename("my-great-tempfile")
 	if p.Tempfile != expect2 {
-		t.Errorf("p.SetTempfileWithBaseName() should set %s, but: %s", expect2, p.Tempfile)
+		t.Errorf("p.SetTempfileByBasename() should set %s, but: %s", expect2, p.Tempfile)
 	}
 }
 

--- a/mackerel-plugin_test.go
+++ b/mackerel-plugin_test.go
@@ -479,23 +479,23 @@ func TestTempfilenameFromExecutableFilePath(t *testing.T) {
 	}
 }
 
-func TestGenerateTempfilePathWithBase(t *testing.T) {
+func TestSetTempfileWithBaseName(t *testing.T) {
 	var p MackerelPlugin
 
 	expect1 := filepath.Join(os.TempDir(), "my-super-tempfile")
-	filename1 := p.GenerateTempfilePathWithBase("my-super-tempfile")
-	if filename1 != expect1 {
-		t.Errorf("p.GenerateTempfilePathWithBase() should be %s, but: %s", expect1, filename1)
+	p.SetTempfileWithBaseName("my-super-tempfile")
+	if p.Tempfile != expect1 {
+		t.Errorf("p.SetTempfileWithBaseName() should set %s, but: %s", expect1, p.Tempfile)
 	}
 
 	origDir := os.Getenv("MACKEREL_PLUGIN_WORKDIR")
 	os.Setenv("MACKEREL_PLUGIN_WORKDIR", "/tmp/somewhere")
 	defer os.Setenv("MACKEREL_PLUGIN_WORKDIR", origDir)
 
-	expect2 := filepath.Join("/tmp/somewhere/my-great-tempfile")
-	filename2 := p.GenerateTempfilePathWithBase("my-great-tempfile")
-	if filename2 != expect2 {
-		t.Errorf("p.GenerateTempfilePathWithBase() should be %s, but: %s", expect2, filename2)
+	expect2 := "/tmp/somewhere/my-great-tempfile"
+	p.SetTempfileWithBaseName("my-great-tempfile")
+	if p.Tempfile != expect2 {
+		t.Errorf("p.SetTempfileWithBaseName() should set %s, but: %s", expect2, p.Tempfile)
 	}
 }
 

--- a/mackerel-plugin_test.go
+++ b/mackerel-plugin_test.go
@@ -479,6 +479,26 @@ func TestTempfilenameFromExecutableFilePath(t *testing.T) {
 	}
 }
 
+func TestGenerateTempfilePathWithBase(t *testing.T) {
+	var p MackerelPlugin
+
+	expect1 := filepath.Join(os.TempDir(), "my-super-tempfile")
+	filename1 := p.GenerateTempfilePathWithBase("my-super-tempfile")
+	if filename1 != expect1 {
+		t.Errorf("p.GenerateTempfilePathWithBase() should be %s, but: %s", expect1, filename1)
+	}
+
+	origDir := os.Getenv("MACKEREL_PLUGIN_WORKDIR")
+	os.Setenv("MACKEREL_PLUGIN_WORKDIR", "/tmp/somewhere")
+	defer os.Setenv("MACKEREL_PLUGIN_WORKDIR", origDir)
+
+	expect2 := filepath.Join("/tmp/somewhere/my-great-tempfile")
+	filename2 := p.GenerateTempfilePathWithBase("my-great-tempfile")
+	if filename2 != expect2 {
+		t.Errorf("p.GenerateTempfilePathWithBase() should be %s, but: %s", expect2, filename2)
+	}
+}
+
 func ExamplePluginWithPrefixOutputDefinitions() {
 	helper := NewMackerelPlugin(testP{})
 	helper.OutputDefinitions()


### PR DESCRIPTION
This allows plugins to set default Tempfile considering MACKEREL_PLUGIN_WORKDIR environmental value.  It's useful when a plugin wants to set default Tempfile path like [mackerel-plugin-fluentd](https://github.com/mackerelio/mackerel-agent-plugins/blob/master/mackerel-plugin-fluentd/lib/fluentd.go#L157-L167).