### PR TITLE
Refactor metric values

### DIFF
--- a/mackerel-plugin.go
+++ b/mackerel-plugin.go
@@ -35,6 +35,12 @@ type Graphs struct {
 	Metrics []Metrics `json:"metrics"`
 }
 
+// MetricValues represents a collection of metric values and its timestamp
+type MetricValues struct {
+	Values    map[string]interface{}
+	Timestamp time.Time
+}
+
 // Plugin is old interface of mackerel-plugin
 type Plugin interface {
 	FetchMetrics() (map[string]interface{}, error)

--- a/mackerel-plugin.go
+++ b/mackerel-plugin.go
@@ -92,7 +92,7 @@ func (h *MackerelPlugin) printValue(w io.Writer, key string, value interface{}, 
 	}
 }
 
-func (h *MackerelPlugin) fetchLastValues() (map[string]interface{}, time.Time, error) {
+func (h *MackerelPlugin) FetchLastValues() (map[string]interface{}, time.Time, error) {
 	if !h.hasDiff() {
 		return nil, time.Unix(0, 0), nil
 	}
@@ -318,9 +318,9 @@ func (h *MackerelPlugin) OutputValues() {
 		log.Fatalln("OutputValues: ", err)
 	}
 
-	lastStat, lastTime, err := h.fetchLastValues()
+	lastStat, lastTime, err := h.FetchLastValues()
 	if err != nil {
-		log.Println("fetchLastValues (ignore):", err)
+		log.Println("FetchLastValues (ignore):", err)
 	}
 
 	for key, graph := range h.GraphDefinition() {

--- a/mackerel-plugin_test.go
+++ b/mackerel-plugin_test.go
@@ -148,11 +148,16 @@ func ExampleFormatValues() {
 	var mp MackerelPlugin
 	prefix := "foo"
 	metric := Metrics{Name: "cmd_get", Label: "Get", Diff: true, Type: "uint64"}
-	stat := map[string]interface{}{"cmd_get": uint64(1000)}
-	lastStat := map[string]interface{}{"cmd_get": uint64(500), ".last_diff.cmd_get": 300.0}
 	now := time.Unix(1437227240, 0)
-	lastTime := now.Add(-time.Duration(60) * time.Second)
-	mp.formatValues(prefix, metric, stat, lastStat, now, lastTime)
+	metricValues := MetricValues{
+		Values:    map[string]interface{}{"cmd_get": uint64(1000)},
+		Timestamp: now,
+	}
+	lastMetricValues := MetricValues{
+		Values:    map[string]interface{}{"cmd_get": uint64(500), ".last_diff.cmd_get": 300.0},
+		Timestamp: now.Add(-time.Duration(60) * time.Second),
+	}
+	mp.formatValues(prefix, metric, metricValues, lastMetricValues)
 
 	// Output:
 	// foo.cmd_get	500.000000	1437227240
@@ -164,12 +169,17 @@ func ExampleFormatValuesAbsoluteName() {
 	metricA := Metrics{Name: "cmd_get", Label: "Get", Diff: true, Type: "uint64", AbsoluteName: true}
 	prefixB := "bar"
 	metricB := Metrics{Name: "cmd_get", Label: "Get", Diff: true, Type: "uint64", AbsoluteName: true}
-	stat := map[string]interface{}{"foo.cmd_get": uint64(1000), "bar.cmd_get": uint64(1234)}
-	lastStat := map[string]interface{}{"foo.cmd_get": uint64(500), ".last_diff.foo.cmd_get": 300.0, "bar.cmd_get": uint64(600), ".last_diff.bar.cmd_get": 400.0}
 	now := time.Unix(1437227240, 0)
-	lastTime := now.Add(-time.Duration(60) * time.Second)
-	mp.formatValues(prefixA, metricA, stat, lastStat, now, lastTime)
-	mp.formatValues(prefixB, metricB, stat, lastStat, now, lastTime)
+	metricValues := MetricValues{
+		Values:    map[string]interface{}{"foo.cmd_get": uint64(1000), "bar.cmd_get": uint64(1234)},
+		Timestamp: now,
+	}
+	lastMetricValues := MetricValues{
+		Values:    map[string]interface{}{"foo.cmd_get": uint64(500), ".last_diff.foo.cmd_get": 300.0, "bar.cmd_get": uint64(600), ".last_diff.bar.cmd_get": 400.0},
+		Timestamp: now.Add(-time.Duration(60) * time.Second),
+	}
+	mp.formatValues(prefixA, metricA, metricValues, lastMetricValues)
+	mp.formatValues(prefixB, metricB, metricValues, lastMetricValues)
 
 	// Output:
 	// foo.cmd_get	500.000000	1437227240
@@ -180,11 +190,16 @@ func ExampleFormatValuesAbsoluteNameButNoPrefix() {
 	var mp MackerelPlugin
 	prefix := ""
 	metric := Metrics{Name: "cmd_get", Label: "Get", Diff: true, Type: "uint64", AbsoluteName: true}
-	stat := map[string]interface{}{"cmd_get": uint64(1000)}
-	lastStat := map[string]interface{}{"cmd_get": uint64(500), ".last_diff.cmd_get": 300.0}
 	now := time.Unix(1437227240, 0)
-	lastTime := now.Add(-time.Duration(60) * time.Second)
-	mp.formatValues(prefix, metric, stat, lastStat, now, lastTime)
+	metricValues := MetricValues{
+		Values:    map[string]interface{}{"cmd_get": uint64(1000)},
+		Timestamp: now,
+	}
+	lastMetricValues := MetricValues{
+		Values:    map[string]interface{}{"cmd_get": uint64(500), ".last_diff.cmd_get": 300.0},
+		Timestamp: now.Add(-time.Duration(60) * time.Second),
+	}
+	mp.formatValues(prefix, metric, metricValues, lastMetricValues)
 
 	// Output:
 	// cmd_get	500.000000	1437227240
@@ -194,11 +209,16 @@ func ExampleFormatValuesWithCounterReset() {
 	var mp MackerelPlugin
 	prefix := "foo"
 	metric := Metrics{Name: "cmd_get", Label: "Get", Diff: true, Type: "uint64"}
-	stat := map[string]interface{}{"cmd_get": uint64(10)}
-	lastStat := map[string]interface{}{"cmd_get": uint64(500), ".last_diff.cmd_get": 300.0}
 	now := time.Unix(1437227240, 0)
-	lastTime := now.Add(-time.Duration(60) * time.Second)
-	mp.formatValues(prefix, metric, stat, lastStat, now, lastTime)
+	metricValues := MetricValues{
+		Values:    map[string]interface{}{"cmd_get": uint64(10)},
+		Timestamp: now,
+	}
+	lastMetricValues := MetricValues{
+		Values:    map[string]interface{}{"cmd_get": uint64(500), ".last_diff.cmd_get": 300.0},
+		Timestamp: now.Add(-time.Duration(60) * time.Second),
+	}
+	mp.formatValues(prefix, metric, metricValues, lastMetricValues)
 
 	// Output:
 }
@@ -207,11 +227,16 @@ func ExampleFormatFloatValuesWithCounterReset() {
 	var mp MackerelPlugin
 	prefix := "foo"
 	metric := Metrics{Name: "cmd_get", Label: "Get", Diff: true, Type: "float"}
-	stat := map[string]interface{}{"cmd_get": 10.0}
-	lastStat := map[string]interface{}{"cmd_get": 500.0, ".last_diff.cmd_get": 300.0}
 	now := time.Unix(1437227240, 0)
-	lastTime := now.Add(-time.Duration(60) * time.Second)
-	mp.formatValues(prefix, metric, stat, lastStat, now, lastTime)
+	metricValues := MetricValues{
+		Values:    map[string]interface{}{"cmd_get": 10.0},
+		Timestamp: now,
+	}
+	lastMetricValues := MetricValues{
+		Values:    map[string]interface{}{"cmd_get": 500.0, ".last_diff.cmd_get": 300.0},
+		Timestamp: now.Add(-time.Duration(60) * time.Second),
+	}
+	mp.formatValues(prefix, metric, metricValues, lastMetricValues)
 
 	// Output:
 }
@@ -220,11 +245,16 @@ func ExampleFormatValuesWithOverflow() {
 	var mp MackerelPlugin
 	prefix := "foo"
 	metric := Metrics{Name: "cmd_get", Label: "Get", Diff: true, Type: "uint64"}
-	stat := map[string]interface{}{"cmd_get": uint64(500)}
-	lastStat := map[string]interface{}{"cmd_get": uint64(math.MaxUint64 - 100), ".last_diff.cmd_get": float64(100.0)}
 	now := time.Unix(1437227240, 0)
-	lastTime := now.Add(-time.Duration(60) * time.Second)
-	mp.formatValues(prefix, metric, stat, lastStat, now, lastTime)
+	metricValues := MetricValues{
+		Values:    map[string]interface{}{"cmd_get": uint64(500)},
+		Timestamp: now,
+	}
+	lastMetricValues := MetricValues{
+		Values:    map[string]interface{}{"cmd_get": uint64(math.MaxUint64 - 100), ".last_diff.cmd_get": float64(100.0)},
+		Timestamp: now.Add(-time.Duration(60) * time.Second),
+	}
+	mp.formatValues(prefix, metric, metricValues, lastMetricValues)
 
 	// Output:
 	// foo.cmd_get	601.000000	1437227240
@@ -234,11 +264,16 @@ func ExampleFormatValuesWithOverflowAndTooHighDifference() {
 	var mp MackerelPlugin
 	prefix := "foo"
 	metric := Metrics{Name: "cmd_get", Label: "Get", Diff: true, Type: "uint64"}
-	stat := map[string]interface{}{"cmd_get": uint64(500)}
-	lastStat := map[string]interface{}{"cmd_get": uint64(math.MaxUint64 - 100), ".last_diff.cmd_get": float64(10.0)}
 	now := time.Unix(1437227240, 0)
-	lastTime := now.Add(-time.Duration(60) * time.Second)
-	mp.formatValues(prefix, metric, stat, lastStat, now, lastTime)
+	metricValues := MetricValues{
+		Values:    map[string]interface{}{"cmd_get": uint64(500)},
+		Timestamp: now,
+	}
+	lastMetricValues := MetricValues{
+		Values:    map[string]interface{}{"cmd_get": uint64(math.MaxUint64 - 100), ".last_diff.cmd_get": float64(10.0)},
+		Timestamp: now.Add(-time.Duration(60) * time.Second),
+	}
+	mp.formatValues(prefix, metric, metricValues, lastMetricValues)
 
 	// Output:
 }
@@ -247,11 +282,16 @@ func ExampleFormatValuesWithOverflowAndNoLastDiff() {
 	var mp MackerelPlugin
 	prefix := "foo"
 	metric := Metrics{Name: "cmd_get", Label: "Get", Diff: true, Type: "uint64"}
-	stat := map[string]interface{}{"cmd_get": uint64(500)}
-	lastStat := map[string]interface{}{"cmd_get": uint64(math.MaxUint64 - 100)}
 	now := time.Unix(1437227240, 0)
-	lastTime := now.Add(-time.Duration(60) * time.Second)
-	mp.formatValues(prefix, metric, stat, lastStat, now, lastTime)
+	metricValues := MetricValues{
+		Values:    map[string]interface{}{"cmd_get": uint64(500)},
+		Timestamp: now,
+	}
+	lastMetricValues := MetricValues{
+		Values:    map[string]interface{}{"cmd_get": uint64(math.MaxUint64 - 100)},
+		Timestamp: now.Add(-time.Duration(60) * time.Second),
+	}
+	mp.formatValues(prefix, metric, metricValues, lastMetricValues)
 
 	// Output:
 }
@@ -260,11 +300,16 @@ func ExampleFormatValuesWithWildcard() {
 	var mp MackerelPlugin
 	prefix := "foo.#"
 	metric := Metrics{Name: "bar", Label: "Get", Diff: true, Type: "uint64"}
-	stat := map[string]interface{}{"foo.1.bar": uint64(1000), "foo.2.bar": uint64(2000)}
-	lastStat := map[string]interface{}{"foo.1.bar": uint64(500), ".last_diff.foo.1.bar": float64(2.0)}
 	now := time.Unix(1437227240, 0)
-	lastTime := now.Add(-time.Duration(60) * time.Second)
-	mp.formatValuesWithWildcard(prefix, metric, stat, lastStat, now, lastTime)
+	metricValues := MetricValues{
+		Values:    map[string]interface{}{"foo.1.bar": uint64(1000), "foo.2.bar": uint64(2000)},
+		Timestamp: now,
+	}
+	lastMetricValues := MetricValues{
+		Values:    map[string]interface{}{"foo.1.bar": uint64(500), ".last_diff.foo.1.bar": float64(2.0)},
+		Timestamp: now.Add(-time.Duration(60) * time.Second),
+	}
+	mp.formatValuesWithWildcard(prefix, metric, metricValues, lastMetricValues)
 
 	// Output:
 	// foo.1.bar	500.000000	1437227240
@@ -275,11 +320,16 @@ func ExampleFormatValuesWithWildcardAndAbsoluteName() {
 	var mp MackerelPlugin
 	prefix := "foo.#"
 	metric := Metrics{Name: "bar", Label: "Get", Diff: true, Type: "uint64", AbsoluteName: true}
-	stat := map[string]interface{}{"foo.1.bar": uint64(1000), "foo.2.bar": uint64(2000)}
-	lastStat := map[string]interface{}{"foo.1.bar": uint64(500), ".last_diff.foo.1.bar": float64(2.0)}
 	now := time.Unix(1437227240, 0)
-	lastTime := now.Add(-time.Duration(60) * time.Second)
-	mp.formatValuesWithWildcard(prefix, metric, stat, lastStat, now, lastTime)
+	metricValues := MetricValues{
+		Values:    map[string]interface{}{"foo.1.bar": uint64(1000), "foo.2.bar": uint64(2000)},
+		Timestamp: now,
+	}
+	lastMetricValues := MetricValues{
+		Values:    map[string]interface{}{"foo.1.bar": uint64(500), ".last_diff.foo.1.bar": float64(2.0)},
+		Timestamp: now.Add(-time.Duration(60) * time.Second),
+	}
+	mp.formatValuesWithWildcard(prefix, metric, metricValues, lastMetricValues)
 
 	// Output:
 	// foo.1.bar	500.000000	1437227240
@@ -289,11 +339,16 @@ func ExampleFormatValuesWithWildcardAndNoDiff() {
 	var mp MackerelPlugin
 	prefix := "foo.#"
 	metric := Metrics{Name: "bar", Label: "Get", Diff: false}
-	stat := map[string]interface{}{"foo.1.bar": float64(1000)}
-	lastStat := map[string]interface{}{"foo.1.bar": float64(500), ".last_diff.foo.1.bar": float64(2.0)}
 	now := time.Unix(1437227240, 0)
-	lastTime := now.Add(-time.Duration(60) * time.Second)
-	mp.formatValuesWithWildcard(prefix, metric, stat, lastStat, now, lastTime)
+	metricValues := MetricValues{
+		Values:    map[string]interface{}{"foo.1.bar": float64(1000)},
+		Timestamp: now,
+	}
+	lastMetricValues := MetricValues{
+		Values:    map[string]interface{}{"foo.1.bar": float64(500), ".last_diff.foo.1.bar": float64(2.0)},
+		Timestamp: now.Add(-time.Duration(60) * time.Second),
+	}
+	mp.formatValuesWithWildcard(prefix, metric, metricValues, lastMetricValues)
 
 	// Output:
 	// foo.1.bar	1000.000000	1437227240
@@ -303,11 +358,16 @@ func ExampleFormatValuesWithWildcardAstarisk() {
 	var mp MackerelPlugin
 	prefix := "foo"
 	metric := Metrics{Name: "*", Label: "Get", Diff: true, Type: "uint64"}
-	stat := map[string]interface{}{"foo.1": uint64(1000), "foo.2": uint64(2000)}
-	lastStat := map[string]interface{}{"foo.1": uint64(500), ".last_diff.foo.1": float64(2.0)}
 	now := time.Unix(1437227240, 0)
-	lastTime := now.Add(-time.Duration(60) * time.Second)
-	mp.formatValuesWithWildcard(prefix, metric, stat, lastStat, now, lastTime)
+	metricValues := MetricValues{
+		Values:    map[string]interface{}{"foo.1": uint64(1000), "foo.2": uint64(2000)},
+		Timestamp: now,
+	}
+	lastMetricValues := MetricValues{
+		Values:    map[string]interface{}{"foo.1": uint64(500), ".last_diff.foo.1": float64(2.0)},
+		Timestamp: now.Add(-time.Duration(60) * time.Second),
+	}
+	mp.formatValuesWithWildcard(prefix, metric, metricValues, lastMetricValues)
 
 	// Output:
 	// foo.1	500.000000	1437227240
@@ -516,7 +576,7 @@ func ExamplePluginWithPrefixOutputValues() {
 	var lastStat map[string]interface{}
 	now := time.Unix(1437227240, 0)
 	lastTime := time.Unix(0, 0)
-	helper.formatValues(key, metric, stat, lastStat, now, lastTime)
+	helper.formatValues(key, metric, MetricValues{Values: stat, Timestamp: now}, MetricValues{Values: lastStat, Timestamp: lastTime})
 
 	// Output:
 	// testP.bar	15.000000	1437227240
@@ -530,7 +590,7 @@ func ExamplePluginWithPrefixOutputValues2() {
 	var lastStat map[string]interface{}
 	now := time.Unix(1437227240, 0)
 	lastTime := time.Unix(0, 0)
-	helper.formatValues(key, metric, stat, lastStat, now, lastTime)
+	helper.formatValues(key, metric, MetricValues{Values: stat, Timestamp: now}, MetricValues{Values: lastStat, Timestamp: lastTime})
 
 	// Output:
 	// testP.fuga.baz	18.000000	1437227240

--- a/mackerel-plugin_test.go
+++ b/mackerel-plugin_test.go
@@ -152,7 +152,7 @@ func ExampleFormatValues() {
 	lastStat := map[string]interface{}{"cmd_get": uint64(500), ".last_diff.cmd_get": 300.0}
 	now := time.Unix(1437227240, 0)
 	lastTime := now.Add(-time.Duration(60) * time.Second)
-	mp.formatValues(prefix, metric, &stat, &lastStat, now, lastTime)
+	mp.formatValues(prefix, metric, stat, lastStat, now, lastTime)
 
 	// Output:
 	// foo.cmd_get	500.000000	1437227240
@@ -168,8 +168,8 @@ func ExampleFormatValuesAbsoluteName() {
 	lastStat := map[string]interface{}{"foo.cmd_get": uint64(500), ".last_diff.foo.cmd_get": 300.0, "bar.cmd_get": uint64(600), ".last_diff.bar.cmd_get": 400.0}
 	now := time.Unix(1437227240, 0)
 	lastTime := now.Add(-time.Duration(60) * time.Second)
-	mp.formatValues(prefixA, metricA, &stat, &lastStat, now, lastTime)
-	mp.formatValues(prefixB, metricB, &stat, &lastStat, now, lastTime)
+	mp.formatValues(prefixA, metricA, stat, lastStat, now, lastTime)
+	mp.formatValues(prefixB, metricB, stat, lastStat, now, lastTime)
 
 	// Output:
 	// foo.cmd_get	500.000000	1437227240
@@ -184,7 +184,7 @@ func ExampleFormatValuesAbsoluteNameButNoPrefix() {
 	lastStat := map[string]interface{}{"cmd_get": uint64(500), ".last_diff.cmd_get": 300.0}
 	now := time.Unix(1437227240, 0)
 	lastTime := now.Add(-time.Duration(60) * time.Second)
-	mp.formatValues(prefix, metric, &stat, &lastStat, now, lastTime)
+	mp.formatValues(prefix, metric, stat, lastStat, now, lastTime)
 
 	// Output:
 	// cmd_get	500.000000	1437227240
@@ -198,7 +198,7 @@ func ExampleFormatValuesWithCounterReset() {
 	lastStat := map[string]interface{}{"cmd_get": uint64(500), ".last_diff.cmd_get": 300.0}
 	now := time.Unix(1437227240, 0)
 	lastTime := now.Add(-time.Duration(60) * time.Second)
-	mp.formatValues(prefix, metric, &stat, &lastStat, now, lastTime)
+	mp.formatValues(prefix, metric, stat, lastStat, now, lastTime)
 
 	// Output:
 }
@@ -211,7 +211,7 @@ func ExampleFormatFloatValuesWithCounterReset() {
 	lastStat := map[string]interface{}{"cmd_get": 500.0, ".last_diff.cmd_get": 300.0}
 	now := time.Unix(1437227240, 0)
 	lastTime := now.Add(-time.Duration(60) * time.Second)
-	mp.formatValues(prefix, metric, &stat, &lastStat, now, lastTime)
+	mp.formatValues(prefix, metric, stat, lastStat, now, lastTime)
 
 	// Output:
 }
@@ -224,7 +224,7 @@ func ExampleFormatValuesWithOverflow() {
 	lastStat := map[string]interface{}{"cmd_get": uint64(math.MaxUint64 - 100), ".last_diff.cmd_get": float64(100.0)}
 	now := time.Unix(1437227240, 0)
 	lastTime := now.Add(-time.Duration(60) * time.Second)
-	mp.formatValues(prefix, metric, &stat, &lastStat, now, lastTime)
+	mp.formatValues(prefix, metric, stat, lastStat, now, lastTime)
 
 	// Output:
 	// foo.cmd_get	601.000000	1437227240
@@ -238,7 +238,7 @@ func ExampleFormatValuesWithOverflowAndTooHighDifference() {
 	lastStat := map[string]interface{}{"cmd_get": uint64(math.MaxUint64 - 100), ".last_diff.cmd_get": float64(10.0)}
 	now := time.Unix(1437227240, 0)
 	lastTime := now.Add(-time.Duration(60) * time.Second)
-	mp.formatValues(prefix, metric, &stat, &lastStat, now, lastTime)
+	mp.formatValues(prefix, metric, stat, lastStat, now, lastTime)
 
 	// Output:
 }
@@ -251,7 +251,7 @@ func ExampleFormatValuesWithOverflowAndNoLastDiff() {
 	lastStat := map[string]interface{}{"cmd_get": uint64(math.MaxUint64 - 100)}
 	now := time.Unix(1437227240, 0)
 	lastTime := now.Add(-time.Duration(60) * time.Second)
-	mp.formatValues(prefix, metric, &stat, &lastStat, now, lastTime)
+	mp.formatValues(prefix, metric, stat, lastStat, now, lastTime)
 
 	// Output:
 }
@@ -264,7 +264,7 @@ func ExampleFormatValuesWithWildcard() {
 	lastStat := map[string]interface{}{"foo.1.bar": uint64(500), ".last_diff.foo.1.bar": float64(2.0)}
 	now := time.Unix(1437227240, 0)
 	lastTime := now.Add(-time.Duration(60) * time.Second)
-	mp.formatValuesWithWildcard(prefix, metric, &stat, &lastStat, now, lastTime)
+	mp.formatValuesWithWildcard(prefix, metric, stat, lastStat, now, lastTime)
 
 	// Output:
 	// foo.1.bar	500.000000	1437227240
@@ -279,7 +279,7 @@ func ExampleFormatValuesWithWildcardAndAbsoluteName() {
 	lastStat := map[string]interface{}{"foo.1.bar": uint64(500), ".last_diff.foo.1.bar": float64(2.0)}
 	now := time.Unix(1437227240, 0)
 	lastTime := now.Add(-time.Duration(60) * time.Second)
-	mp.formatValuesWithWildcard(prefix, metric, &stat, &lastStat, now, lastTime)
+	mp.formatValuesWithWildcard(prefix, metric, stat, lastStat, now, lastTime)
 
 	// Output:
 	// foo.1.bar	500.000000	1437227240
@@ -293,7 +293,7 @@ func ExampleFormatValuesWithWildcardAndNoDiff() {
 	lastStat := map[string]interface{}{"foo.1.bar": float64(500), ".last_diff.foo.1.bar": float64(2.0)}
 	now := time.Unix(1437227240, 0)
 	lastTime := now.Add(-time.Duration(60) * time.Second)
-	mp.formatValuesWithWildcard(prefix, metric, &stat, &lastStat, now, lastTime)
+	mp.formatValuesWithWildcard(prefix, metric, stat, lastStat, now, lastTime)
 
 	// Output:
 	// foo.1.bar	1000.000000	1437227240
@@ -307,7 +307,7 @@ func ExampleFormatValuesWithWildcardAstarisk() {
 	lastStat := map[string]interface{}{"foo.1": uint64(500), ".last_diff.foo.1": float64(2.0)}
 	now := time.Unix(1437227240, 0)
 	lastTime := now.Add(-time.Duration(60) * time.Second)
-	mp.formatValuesWithWildcard(prefix, metric, &stat, &lastStat, now, lastTime)
+	mp.formatValuesWithWildcard(prefix, metric, stat, lastStat, now, lastTime)
 
 	// Output:
 	// foo.1	500.000000	1437227240
@@ -516,7 +516,7 @@ func ExamplePluginWithPrefixOutputValues() {
 	var lastStat map[string]interface{}
 	now := time.Unix(1437227240, 0)
 	lastTime := time.Unix(0, 0)
-	helper.formatValues(key, metric, &stat, &lastStat, now, lastTime)
+	helper.formatValues(key, metric, stat, lastStat, now, lastTime)
 
 	// Output:
 	// testP.bar	15.000000	1437227240
@@ -530,7 +530,7 @@ func ExamplePluginWithPrefixOutputValues2() {
 	var lastStat map[string]interface{}
 	now := time.Unix(1437227240, 0)
 	lastTime := time.Unix(0, 0)
-	helper.formatValues(key, metric, &stat, &lastStat, now, lastTime)
+	helper.formatValues(key, metric, stat, lastStat, now, lastTime)
 
 	// Output:
 	// testP.fuga.baz	18.000000	1437227240


### PR DESCRIPTION
The collection of metric values (`map[string]interface{}` in this library) has its timestamp the values are fetched at. Within this pull request I created a MetricValues struct to hold the metric values and the timestamp. Also, I published the FetchLastValues function so that plugin creator can use the last saved metric values.