### PR TITLE
Use sha1 generated from command-line options to deal with tempfile name conflicts

### DIFF
--- a/mackerel-plugin_test.go
+++ b/mackerel-plugin_test.go
@@ -2,10 +2,12 @@ package mackerelplugin
 
 import (
 	"bytes"
+	"crypto/sha1"
 	"fmt"
 	"math"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -491,51 +493,65 @@ func (t testP) MetricKeyPrefix() string {
 }
 
 func TestDefaultTempfile(t *testing.T) {
-	var p MackerelPlugin
+	mp := &MackerelPlugin{}
 	filename := filepath.Base(os.Args[0])
-	expect := filepath.Join(os.TempDir(), fmt.Sprintf("mackerel-plugin-%s", filename))
-	if p.tempfilename() != expect {
-		t.Errorf("p.tempfilename() should be %s, but: %s", expect, p.tempfilename())
+	expect := filepath.Join(os.TempDir(), fmt.Sprintf(
+		"mackerel-plugin-%s-%x",
+		filename,
+		sha1.Sum([]byte(strings.Join(os.Args[1:], " "))),
+	))
+	if mp.tempfilename() != expect {
+		t.Errorf("mp.tempfilename() should be %s, but: %s", expect, mp.tempfilename())
 	}
 
 	pPrefix := NewMackerelPlugin(testP{})
-	expectForPrefix := filepath.Join(os.TempDir(), "mackerel-plugin-testP")
+	expectForPrefix := filepath.Join(os.TempDir(), fmt.Sprintf(
+		"mackerel-plugin-testP-%x",
+		sha1.Sum([]byte(strings.Join(os.Args[1:], " "))),
+	))
 	if pPrefix.tempfilename() != expectForPrefix {
 		t.Errorf("pPrefix.tempfilename() should be %s, but: %s", expectForPrefix, pPrefix.tempfilename())
 	}
 }
 
 func TestTempfilenameFromExecutableFilePath(t *testing.T) {
-	var p MackerelPlugin
+	mp := &MackerelPlugin{}
 
 	wd, _ := os.Getwd()
 	// not PluginWithPrefix, regular filename
-	expect1 := filepath.Join(os.TempDir(), "mackerel-plugin-foobar")
-	filename1 := p.generateTempfilePath(filepath.Join(wd, "foobar"))
+	expect1 := filepath.Join(os.TempDir(), "mackerel-plugin-foobar-da39a3ee5e6b4b0d3255bfef95601890afd80709")
+	filename1 := mp.generateTempfilePath([]string{filepath.Join(wd, "foobar")})
 	if filename1 != expect1 {
 		t.Errorf("p.generateTempfilePath() should be %s, but: %s", expect1, filename1)
 	}
 
 	// not PluginWithPrefix, contains some characters to be sanitized
-	expect2 := filepath.Join(os.TempDir(), "mackerel-plugin-some_sanitized_name_1.2")
-	filename2 := p.generateTempfilePath(filepath.Join(wd, "some sanitized:name+1.2"))
+	expect2 := filepath.Join(os.TempDir(), "mackerel-plugin-some_sanitized_name_1.2-da39a3ee5e6b4b0d3255bfef95601890afd80709")
+	filename2 := mp.generateTempfilePath([]string{filepath.Join(wd, "some sanitized:name+1.2")})
 	if filename2 != expect2 {
 		t.Errorf("p.generateTempfilePath() should be %s, but: %s", expect2, filename2)
 	}
 
 	// not PluginWithPrefix, begins with "mackerel-plugin-"
-	expect3 := filepath.Join(os.TempDir(), "mackerel-plugin-trimmed")
-	filename3 := p.generateTempfilePath(filepath.Join(wd, "mackerel-plugin-trimmed"))
+	expect3 := filepath.Join(os.TempDir(), "mackerel-plugin-trimmed-da39a3ee5e6b4b0d3255bfef95601890afd80709")
+	filename3 := mp.generateTempfilePath([]string{filepath.Join(wd, "mackerel-plugin-trimmed")})
 	if filename3 != expect3 {
 		t.Errorf("p.generateTempfilePath() should be %s, but: %s", expect3, filename3)
 	}
 
 	// PluginWithPrefix ignores current filename
 	pPrefix := NewMackerelPlugin(testP{})
-	expectForPrefix := filepath.Join(os.TempDir(), "mackerel-plugin-testP")
-	filenameForPrefix := pPrefix.generateTempfilePath(filepath.Join(wd, "foo"))
+	expectForPrefix := filepath.Join(os.TempDir(), "mackerel-plugin-testP-da39a3ee5e6b4b0d3255bfef95601890afd80709")
+	filenameForPrefix := pPrefix.generateTempfilePath([]string{filepath.Join(wd, "foo")})
 	if filenameForPrefix != expectForPrefix {
 		t.Errorf("pPrefix.generateTempfilePath() should be %s, but: %s", expectForPrefix, filenameForPrefix)
+	}
+
+	// Generate sha1 using command-line options, and use it for filename
+	expect5 := filepath.Join(os.TempDir(), "mackerel-plugin-mysql-9045504f8fadd7ddcc8962ec1d9fc70e3f7ba627")
+	filename5 := mp.generateTempfilePath([]string{filepath.Join(wd, "mackerel-plugin-mysql"), "-host", "hostname1", "-port", "3306"})
+	if filename5 != expect5 {
+		t.Errorf("p.generateTempfilePath() should be %s, but: %s", expect5, filename5)
 	}
 }
 


### PR DESCRIPTION
This PR fixes the same problem as https://github.com/mackerelio/go-mackerel-plugin/pull/14 .

A tempfile name will conflict if we use same metric prefix and custom_identifier option in mackerel-agent.conf.  The following settings is example.

```
[plugin.metrics.mysql]
command = "mackerel-plugin-mysql -host=sample-db001.xxxxxxx.ap-northeast-1.rds.amazonaws.com -port=3306 -username=user"
custom_identifier = "sample-db001.xxxxxxx.ap-northeast-1.rds.amazonaws.com"

[plugin.metrics.mysql]
command = "mackerel-plugin-mysql -host=sample-db002.yyyyyyy.ap-northeast-1.rds.amazonaws.com -port=3306 -username=user"
custom_identifier = "sample-db002.yyyyyyy.ap-northeast-1.rds.amazonaws.com"
```

The both setting use `mackerel-plugin-mysql` as tempfile name.  So tempfile name will conflict and the metric of Diff can not be calculated correctly.


I fixed this problem by using sha1 generated from command-line options for tempfile name.