### PR TITLE
Run test on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,6 @@ go:
 
 env:
   - GO111MODULE=on
+
+script:
+  - make test


### PR DESCRIPTION
I know make lint fails but I don't have motivation to make it pass since this library is already deprecated in favor of [go-mackerel-plugin](https://github.com/mackerelio/go-mackerel-plugin). 