### PR TITLE
avoid invalid value: NaN

### DIFF
--- a/mackerel-plugin.go
+++ b/mackerel-plugin.go
@@ -103,12 +103,11 @@ func (h *MackerelPlugin) FetchLastValues() (metricValues MetricValues, err error
 	if !h.hasDiff() {
 		return
 	}
-	metricValues.Timestamp = time.Now()
 
 	f, err := os.Open(h.tempfilename())
 	if err != nil {
 		if os.IsNotExist(err) {
-			return
+			return metricValues, nil
 		}
 		return
 	}
@@ -116,14 +115,14 @@ func (h *MackerelPlugin) FetchLastValues() (metricValues MetricValues, err error
 
 	decoder := json.NewDecoder(f)
 	err = decoder.Decode(&metricValues.Values)
+	if err != nil {
+		return
+	}
 	switch metricValues.Values["_lastTime"].(type) {
 	case float64:
 		metricValues.Timestamp = time.Unix(int64(metricValues.Values["_lastTime"].(float64)), 0)
 	case int64:
 		metricValues.Timestamp = time.Unix(metricValues.Values["_lastTime"].(int64), 0)
-	}
-	if err != nil {
-		return
 	}
 	return
 }

--- a/mackerel-plugin.go
+++ b/mackerel-plugin.go
@@ -345,9 +345,6 @@ func (h *MackerelPlugin) OutputValues() {
 
 	lastMetricValues, err := h.fetchLastValuesSafe(metricValues.Timestamp)
 	if err != nil {
-		if err == errStateUpdated {
-			log.Fatalln("OutputValues: ", err)
-		}
 		log.Println("FetchLastValues (ignore):", err)
 	}
 

--- a/mackerel-plugin.go
+++ b/mackerel-plugin.go
@@ -345,6 +345,9 @@ func (h *MackerelPlugin) OutputValues() {
 
 	lastMetricValues, err := h.fetchLastValuesSafe(metricValues.Timestamp)
 	if err != nil {
+		if err == errStateUpdated {
+			log.Fatalln("OutputValues: ", err)
+		}
 		log.Println("FetchLastValues (ignore):", err)
 	}
 

--- a/mackerel-plugin_test.go
+++ b/mackerel-plugin_test.go
@@ -146,6 +146,35 @@ func TestPrintValueFloat64(t *testing.T) {
 	}
 }
 
+type emptyPlugin struct {
+}
+
+func (*emptyPlugin) FetchMetrics() (map[string]interface{}, error) {
+	return nil, nil
+}
+
+func (*emptyPlugin) GraphDefinition() map[string]Graphs {
+	return nil
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}
+
+func TestFetchLastValues_stateFileNotFound(t *testing.T) {
+	var mp MackerelPlugin
+	mp.Plugin = &emptyPlugin{}
+	mp.Tempfile = "state_file_should_not_exist.json"
+	mp.diff = boolPtr(true)
+	m, err := mp.FetchLastValues()
+	if err != nil {
+		t.Fatalf("FetchLastValues: %v", err)
+	}
+	if !m.Timestamp.IsZero() {
+		t.Errorf("Timestamp = %v; want 0001-01-01", m.Timestamp)
+	}
+}
+
 func ExampleFormatValues() {
 	var mp MackerelPlugin
 	prefix := "foo"


### PR DESCRIPTION
ref mackerelio/mackerel-agent-plugins#593

I fixed some cases of occuring NaN.

~~Unfortunately, I added `log.Fatalln` in *OutputValues*, it is very bad, but it requires to avoid breaking the interface.~~

And I don't use `errors.Is` because some packages in mackerelio org is still use go1.12.