### PR TITLE
exit if "state recently updated"; returned

### DIFF
--- a/mackerel-plugin.go
+++ b/mackerel-plugin.go
@@ -345,6 +345,10 @@ func (h *MackerelPlugin) OutputValues() {
 
 	lastMetricValues, err := h.fetchLastValuesSafe(metricValues.Timestamp)
 	if err != nil {
+		if err == errStateUpdated {
+			log.Println("OutputValues: ", err)
+			return
+		}
 		log.Println("FetchLastValues (ignore):", err)
 	}
 


### PR DESCRIPTION
ref #39 

We should stop OutputValues immediately if errStateUpdated.