### PR TITLE
Deprecate this module and add Go 1.18 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,17 +10,17 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-20.04', 'macOS-11', 'windows-2019']
-        go: ['1.17.x', '1.16.x']
+        go: ['1.18.x', '1.17.x']
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/cache@v1
+    - uses: actions/checkout@v3
+    - uses: actions/cache@v2
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-
-    - uses: actions/setup-go@v2
+    - uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go }}
     - run: make lint test

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: deps
 deps:
-	go install golang.org/x/lint/golint
+	go install golang.org/x/lint/golint@latest
 
 .PHONY: lint
 lint: deps

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,11 @@
 // Deprecated: go-mackerel-plugin-helper is still maintained but we recommend to use go-mackerel-plugin instead.
 module github.com/mackerelio/go-mackerel-plugin-helper
 
-go 1.16
+go 1.17
 
 require (
 	github.com/mackerelio/golib v1.2.1
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b
 )
+
+require golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-// Deprecated: go-mackerel-plugin-helper is still maintained but we recommend to use go-mackerel-plugin instead.
+// Deprecated: go-mackerel-plugin-helper is still maintained, but we recommend using go-mackerel-plugin instead.
 module github.com/mackerelio/go-mackerel-plugin-helper
 
 go 1.17

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,4 @@
+// Deprecated: go-mackerel-plugin-helper is still maintained but we recommend to use go-mackerel-plugin instead.
 module github.com/mackerelio/go-mackerel-plugin-helper
 
 go 1.16


### PR DESCRIPTION
We already announced we recommend to use **go-mackerel-plugin** instead of **go-mackerel-plugin-helper**.

In Go 1.17, Go module introduced deprecation notation in **go.mod** file. Thus I use that notation.
https://go.dev/ref/mod#go-mod-file-module-deprecation