### PR TITLE
go.mod from 1.17 to 1.18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,20 +12,4 @@ jobs:
     - uses: actions/checkout@v3
     - uses: golangci/golangci-lint-action@v3
   test:
-    strategy:
-      matrix:
-        os: ['ubuntu-20.04', 'macOS-11', 'windows-2019']
-        go: ['1.18.x', '1.17.x']
-    runs-on: ${{ matrix.os }}
-    steps:
-    - uses: actions/checkout@v3
-    - uses: actions/cache@v2
-      with:
-        path: ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
-    - uses: actions/setup-go@v3
-      with:
-        go-version: ${{ matrix.go }}
-    - run: make test
+    uses: mackerelio/workflows/.github/workflows/go-test.yml@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ on:
     - master
   pull_request:
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: golangci/golangci-lint-action@v3
   test:
     strategy:
       matrix:
@@ -23,4 +28,4 @@ jobs:
     - uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go }}
-    - run: make lint test
+    - run: make test

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,6 @@
 linters-settings:
+  # There was a naming convention mismatch in Example*.
+  # It depends on the output test. Thus, we decide to disable govet.tests, govet.fieldalignment in this package.
   govet:
     enable-all: true
     disable:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,7 @@
+linters-settings:
+  govet:
+    enable-all: true
+    disable:
+      - fieldalignment
+      - tests
+

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,3 @@
-.PHONY: deps
-deps:
-	go install golang.org/x/lint/golint@latest
-
-.PHONY: lint
-lint: deps
-	golint -set_exit_status .
-
 .PHONY: test
 test:
 	go test -v

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 // Deprecated: go-mackerel-plugin-helper is still maintained, but we recommend using go-mackerel-plugin instead.
 module github.com/mackerelio/go-mackerel-plugin-helper
 
-go 1.17
+go 1.18
 
 require github.com/mackerelio/golib v1.2.1

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,4 @@ module github.com/mackerelio/go-mackerel-plugin-helper
 
 go 1.17
 
-require (
-	github.com/mackerelio/golib v1.2.1
-	golang.org/x/lint v0.0.0-20200302205851-738671d3881b
-)
-
-require golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7 // indirect
+require github.com/mackerelio/golib v1.2.1

--- a/go.mod
+++ b/go.mod
@@ -4,3 +4,5 @@ module github.com/mackerelio/go-mackerel-plugin-helper
 go 1.18
 
 require github.com/mackerelio/golib v1.2.1
+
+require golang.org/x/text v0.3.7

--- a/go.sum
+++ b/go.sum
@@ -1,16 +1,2 @@
 github.com/mackerelio/golib v1.2.1 h1:SDcDn6Jw3p9bi1N0bg1Z/ilG5qcBB23qL8xNwrU0gg4=
 github.com/mackerelio/golib v1.2.1/go.mod h1:b8ZaapsHGH1FlEJlCqfD98CqafLeyMevyATDlID2BsM=
-golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
-golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
-golang.org/x/lint v0.0.0-20200302205851-738671d3881b h1:Wh+f8QHJXR411sJR8/vRBTZ7YapZaRvUcLFFJhusH0k=
-golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
-golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
-golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
-golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
-golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7 h1:EBZoQjiKKPaLbPrbpssUfuHtwM6KV/vb4U85g/cigFY=
-golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
-golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/mackerelio/golib v1.2.1 h1:SDcDn6Jw3p9bi1N0bg1Z/ilG5qcBB23qL8xNwrU0gg4=
 github.com/mackerelio/golib v1.2.1/go.mod h1:b8ZaapsHGH1FlEJlCqfD98CqafLeyMevyATDlID2BsM=
+golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
+golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=

--- a/mackerel-plugin.go
+++ b/mackerel-plugin.go
@@ -15,6 +15,9 @@ import (
 	"strings"
 	"time"
 
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+
 	"github.com/mackerelio/golib/pluginutil"
 )
 
@@ -402,7 +405,7 @@ type GraphDef struct {
 
 func title(s string) string {
 	r := strings.NewReplacer(".", " ", "_", " ")
-	return strings.Title(r.Replace(s))
+	return cases.Title(language.Und, cases.NoLower).String(r.Replace(s))
 }
 
 // OutputDefinitions outputs graph definitions

--- a/mackerel-plugin_test.go
+++ b/mackerel-plugin_test.go
@@ -191,7 +191,10 @@ func TestFetchLastValues_readStateSameTime(t *testing.T) {
 		Values:    make(map[string]interface{}),
 		Timestamp: time.Now(),
 	}
-	mp.saveValues(metricValues)
+	err = mp.saveValues(metricValues)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	_, err = mp.fetchLastValuesSafe(metricValues.Timestamp)
 	if err != errStateUpdated {

--- a/mackerel-plugin_test.go
+++ b/mackerel-plugin_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"crypto/sha1"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"os"
 	"path/filepath"
@@ -180,7 +179,7 @@ func TestFetchLastValues_stateFileNotFound(t *testing.T) {
 func TestFetchLastValues_readStateSameTime(t *testing.T) {
 	var mp MackerelPlugin
 	mp.Plugin = &emptyPlugin{}
-	f, err := ioutil.TempFile("", "mackerel-plugin-helper.")
+	f, err := os.CreateTemp("", "mackerel-plugin-helper.")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -750,7 +749,7 @@ func TestSaveStateIfContainsInvalidNumbers(t *testing.T) {
 
 func createTempState(t testing.TB) *os.File {
 	t.Helper()
-	f, err := ioutil.TempFile("", "mackerel-plugin.")
+	f, err := os.CreateTemp("", "mackerel-plugin.")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tools.go
+++ b/tools.go
@@ -1,8 +1,0 @@
-//go:build tools
-// +build tools
-
-package mackerelplugin
-
-import (
-	_ "golang.org/x/lint/golint"
-)


### PR DESCRIPTION
- use golangci-lint
- go.mod from 1.17 to 1.18
